### PR TITLE
Fix for transcript timestamps

### DIFF
--- a/components/Transcript.tsx
+++ b/components/Transcript.tsx
@@ -63,13 +63,19 @@ export const Transcript = forwardRef(function Transcript(
               <div className="flex flex-row gap-x-3">
                 <span
                   className="time text-sm text-slate-400"
-                  data-datetime={new Date().toISOString()}
+                  data-datetime={
+                    message.createdAt
+                      ? new Date(message.createdAt).toISOString()
+                      : ""
+                  }
                 >
-                  {new Date().toLocaleTimeString([], {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    hour12: true,
-                  })}
+                  {message.createdAt
+                    ? new Date(message.createdAt).toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        hour12: true,
+                      })
+                    : ""}
                 </span>
               </div>
               <p>{message.body.text ? message.body.text : message.body}</p>


### PR DESCRIPTION
## What is in this PR?
Resolves an issue where the transcript content timestamps were simply from an empty `new Date()` rather than the `createdAt` datetime from a message object. This therefore prevents an issue where clicking on an insight in the backchannel view would not scroll to the first related message in the transcript.

## Changes in the codebase
- For the data-datetime param in message timestamp tags, run `new Date(message.createdAt)...` rather than the same with no argument.

## Documentation and automated testing
N/A

## Testing this PR
- [ ] Timestamps in a transcript are not all the same/the system time on page load, but rather the time that the message was generated.
