### PR TITLE
Persistent session support for end-users

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This project uses the Next.js [Pages Router](https://nextjs.org/docs/pages).
         Checks the `[id]` and renders an `EventStatus` component.
   - **api/**
     Client-side public API routes; see [Next.js docs](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)
+    - **cookie.ts**
+      Route to see if user has stored cookie and then decrypt it, return tokens and user info.
     - **logout.ts**
       Route to handle user logout by clearing the session cookie.
     - **request.ts**

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -89,7 +89,7 @@ describe("EventAssistantRoom", () => {
 
     let container;
     await act(async () => {
-      const result = render(<EventAssistantRoom />);
+      const result = render(<EventAssistantRoom isAuthenticated={false} />);
       container = result.container;
     });
 
@@ -105,7 +105,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -125,7 +125,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -147,7 +147,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -165,7 +165,7 @@ describe("EventAssistantRoom", () => {
     (RetrieveData as jest.Mock).mockResolvedValue(null);
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -183,7 +183,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -200,7 +200,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -218,7 +218,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -243,7 +243,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -261,7 +261,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -311,7 +311,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -341,7 +341,7 @@ describe("EventAssistantRoom", () => {
     (SendData as jest.Mock).mockResolvedValue({ success: true });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -379,7 +379,7 @@ describe("EventAssistantRoom", () => {
     (SendData as jest.Mock).mockResolvedValue({ success: true });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -409,7 +409,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -439,7 +439,7 @@ describe("EventAssistantRoom", () => {
     );
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -468,10 +468,17 @@ describe("EventAssistantRoom", () => {
     (RetrieveData as jest.Mock).mockResolvedValue({
       agents: [{ id: "agent-456", agentType: "eventAssistant" }],
     });
+
+    // Print all mock data
+    console.log("Full mock data:", {
+      calls: (RetrieveData as jest.Mock).mock.calls,
+      results: (RetrieveData as jest.Mock).mock.results,
+      instances: (RetrieveData as jest.Mock).mock.instances,
+    });
     (SendData as jest.Mock).mockResolvedValue({ success: true });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -501,7 +508,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -516,7 +523,7 @@ describe("EventAssistantRoom", () => {
     (RetrieveData as jest.Mock).mockRejectedValue(new Error("Network error"));
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
@@ -532,7 +539,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -571,7 +578,7 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      render(<EventAssistantRoom />);
+      render(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     // Simulate socket connection
@@ -610,12 +617,80 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      const { rerender } = render(<EventAssistantRoom />);
-      rerender(<EventAssistantRoom />);
+      const { rerender } = render(
+        <EventAssistantRoom isAuthenticated={false} />
+      );
+      rerender(<EventAssistantRoom isAuthenticated={false} />);
     });
 
     await waitFor(() => {
       expect(JoinSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("conversation history is shown if user is already authenticated", async () => {
+    (JoinSession as jest.Mock).mockImplementation((onSuccess) => {
+      onSuccess({ pseudonym: "TestUser", userId: "user-123" });
+    });
+
+    const mockHistory = [
+      {
+        body: "This is a past message.",
+        pseudonym: "TestUser",
+        createdAt: new Date(Date.now() - 100000).toISOString(),
+      },
+      {
+        body: "This is a past response.",
+        pseudonym: "Event Assistant",
+        createdAt: new Date(Date.now() - 90000).toISOString(),
+      },
+    ];
+
+    // Mock RetrieveData to return different values based on the endpoint
+    (RetrieveData as jest.Mock).mockImplementation((endpoint) => {
+      if (endpoint === "conversations/test-conversation-id") {
+        return Promise.resolve({
+          agents: [{ id: "agent-456", agentType: "eventAssistant" }],
+        });
+      }
+      if (
+        endpoint ===
+        "messages/test-conversation-id?channel=direct-user-123-agent-456"
+      ) {
+        return Promise.resolve([...mockHistory]);
+      }
+      return Promise.resolve(null);
+    });
+
+    await act(async () => {
+      render(<EventAssistantRoom isAuthenticated={true} />);
+    });
+
+    // Simulate socket connection
+    await act(async () => {
+      const connectHandler = mockSocket.on.mock.calls.find(
+        (call) => call[0] === "connect"
+      )?.[1];
+      if (connectHandler) connectHandler();
+    });
+
+    await waitFor(() => {
+      expect(RetrieveData).toHaveBeenCalledWith(
+        "conversations/test-conversation-id",
+        "mock-access-token"
+      );
+    });
+
+    await waitFor(() => {
+      expect(RetrieveData).toHaveBeenCalledWith(
+        "messages/test-conversation-id?channel=direct-user-123-agent-456",
+        "mock-access-token"
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("This is a past message.")).toBeInTheDocument();
+      expect(screen.getByText("This is a past response.")).toBeInTheDocument();
     });
   });
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,9 +5,9 @@ import { JWTDecryptResult } from "jose";
 
 export async function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
+  const isAdminRoute = request.nextUrl.pathname.startsWith("/admin");
   try {
     const token = (await cookies()).get("nextspace-session")?.value;
-    const isAdminRoute = request.nextUrl.pathname.startsWith("/admin");
     // If no token and trying to access admin, redirect to signup, else mark as not authenticated
     if (!token) {
       if (isAdminRoute) {
@@ -37,7 +37,8 @@ export async function middleware(request: NextRequest) {
     // jwtDecrypt will throw an error when the token is invalid
     console.error("Middleware auth error:", e);
     const url = request.nextUrl.clone();
-    url.pathname = "/signup";
+    // Redirect to signup if trying to access admin routes
+    if (isAdminRoute) url.pathname = "/signup";
     return NextResponse.redirect(url);
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,14 +1,16 @@
 import { NextResponse, NextRequest } from "next/server";
 import { cookies } from "next/headers";
 import decryptCookie from "./utils/Decrypt";
+import { JWTDecryptResult } from "jose";
 
 export async function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   try {
     const token = (await cookies()).get("nextspace-session")?.value;
+    const isAdminRoute = request.nextUrl.pathname.startsWith("/admin");
     // If no token and trying to access admin, redirect to signup, else mark as not authenticated
     if (!token) {
-      if (request.nextUrl.pathname.startsWith("/admin")) {
+      if (isAdminRoute) {
         const url = request.nextUrl.clone();
         url.pathname = "/signup";
         return NextResponse.redirect(url);
@@ -17,9 +19,10 @@ export async function middleware(request: NextRequest) {
       requestHeaders.set("x-is-authenticated", "false");
       return NextResponse.next({ headers: requestHeaders });
     }
-    const cookie = await decryptCookie(token);
+    const cookie: JWTDecryptResult = await decryptCookie(token);
+
     // Ensure the decrypted cookie has access token
-    if (!cookie || !cookie.access) throw new Error("Not logged in");
+    if (!cookie || !cookie.payload.access) throw new Error("Not logged in");
     requestHeaders.set("x-is-authenticated", "true");
 
     // If logged in and hitting /admin exactly, redirect to /admin/events

--- a/pages/api/cookie.ts
+++ b/pages/api/cookie.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import decryptCookie from "../../utils/Decrypt";
+import { JWTDecryptResult } from "jose";
+
+/**
+ * API Route to simply see if user has stored cookie and then decrypt it, return tokens
+ * @param req - NextApiRequest object
+ * @param res - NextApiResponse object
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  let apiResponse;
+  let responseCode = 200;
+  const token = req.cookies["nextspace-session"] || null;
+
+  if (!token) {
+    responseCode = 401;
+    apiResponse = { error: "No session cookie found" };
+  } else {
+    try {
+      const decrypted: JWTDecryptResult = await decryptCookie(token);
+      apiResponse = {
+        tokens: {
+          access: decrypted.payload.access,
+          refresh: decrypted.payload.refresh,
+        },
+        userId: decrypted.payload.userId,
+        username: decrypted.payload.sub,
+      };
+    } catch (error) {
+      console.error("Failed to decrypt cookie:", error);
+      responseCode = 500;
+      apiResponse = { error: "Failed to decrypt cookie" };
+    }
+  }
+
+  return res.status(responseCode).json(apiResponse);
+}

--- a/pages/api/cookie.ts
+++ b/pages/api/cookie.ts
@@ -3,7 +3,7 @@ import decryptCookie from "../../utils/Decrypt";
 import { JWTDecryptResult } from "jose";
 
 /**
- * API Route to simply see if user has stored cookie and then decrypt it, return tokens
+ * API Route to simply see if user has stored cookie and then decrypt it, return tokens and user info
  * @param req - NextApiRequest object
  * @param res - NextApiResponse object
  */

--- a/pages/api/session.ts
+++ b/pages/api/session.ts
@@ -24,6 +24,7 @@ export default async function handler(
   const cookie = await new EncryptJWT({
     access: sessionData.accessToken,
     refresh: sessionData.refreshToken,
+    userId: sessionData.userId,
   })
     .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256" })
     .setExpirationTime("30 days")

--- a/pages/api/session.ts
+++ b/pages/api/session.ts
@@ -20,10 +20,14 @@ export default async function handler(
   const sessionData = req.body;
   const secret = new TextEncoder().encode(process.env.SESSION_SECRET!);
 
-  if (sessionData.expiration && typeof sessionData.expiration !== "number") {
+  // Check if expirationFromNow is a number if provided
+  if (
+    sessionData.expirationFromNow &&
+    typeof sessionData.expirationFromNow !== "number"
+  ) {
     res
       .status(400)
-      .json({ error: "Expiration must be a number representing seconds." });
+      .json({ error: "expirationFromNow must be a number in seconds." });
     return;
   }
 
@@ -34,18 +38,22 @@ export default async function handler(
     userId: sessionData.userId,
   })
     .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256" })
-    .setExpirationTime(sessionData.expiration || "30 days")
+    .setExpirationTime(
+      sessionData.expirationFromNow
+        ? Math.floor(Date.now() / 1000) + sessionData.expirationFromNow
+        : "30d"
+    )
     .setSubject(sessionData.username)
     .setIssuedAt()
     .encrypt(secret);
+
+  const maxAge = sessionData.expirationFromNow || 30 * 24 * 60 * 60;
 
   res.setHeader(
     "Set-Cookie",
     `nextspace-session=${cookie}; HttpOnly; ${
       process.env.NODE_ENV === "production" ? "Secure" : ""
-    }; SameSite=Strict; Max-Age=${
-      sessionData.expiration || 30 * 24 * 60 * 60
-    }; Path=/`
+    }; SameSite=Strict; Max-Age=${maxAge}; Path=/`
   );
   res.status(200).json({ message: "Successfully set cookie!" });
 }

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -16,7 +16,7 @@ export const getServerSideProps = async (context: { req: any }) => {
   return CheckAuthHeader(context.req.headers);
 };
 
-function EventAssistantRoom() {
+function EventAssistantRoom({ isAuthenticated }: { isAuthenticated: boolean }) {
   const router = useRouter();
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -36,6 +36,7 @@ function EventAssistantRoom() {
   useEffect(() => {
     if (socket || joining) return;
     setJoining(true);
+
     JoinSession(
       (result) => {
         setPseudonym(result.pseudonym);
@@ -49,9 +50,10 @@ function EventAssistantRoom() {
       },
       (error) => {
         setErrorMessage(error);
-      }
+      },
+      isAuthenticated
     );
-  }, [socket, joining]);
+  }, [socket, joining, isAuthenticated]);
 
   useEffect(() => {
     if (!socket) return;

--- a/pages/backchannel.tsx
+++ b/pages/backchannel.tsx
@@ -22,8 +22,13 @@ import {
 
 import { DirectMessage } from "../components";
 import { components } from "../types";
+import { CheckAuthHeader } from "../utils/Helpers";
 
-function BackchannelRoom() {
+export const getServerSideProps = async (context: { req: any }) => {
+  return CheckAuthHeader(context.req.headers);
+};
+
+function BackchannelRoom({ isAuthenticated }: { isAuthenticated: boolean }) {
   const router = useRouter();
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -59,9 +64,10 @@ function BackchannelRoom() {
       },
       (error) => {
         setErrorMessage(error);
-      }
+      },
+      isAuthenticated
     );
-  }, [joining]);
+  }, [joining, isAuthenticated]);
 
   useEffect(() => {
     if (!socket) return;
@@ -285,6 +291,7 @@ function BackchannelRoom() {
                   <div className="w-11/12 lg:w-4/5">
                     {/* Quick Response Buttons */}
                     <div className="flex flex-row justify-center gap-x-2 md:gap-x-3 items-center text-xs p-2">
+                      <p>{`Pseudonym: ${pseudonym}`}</p>
                       <QuickResponseButton label="Let's move on" icon="😀" />
                       <QuickResponseButton label="That's cool" icon="🌟" />
                       <QuickResponseButton label="I'm confused" icon="😵‍💫" />

--- a/pages/backchannel.tsx
+++ b/pages/backchannel.tsx
@@ -291,7 +291,6 @@ function BackchannelRoom({ isAuthenticated }: { isAuthenticated: boolean }) {
                   <div className="w-11/12 lg:w-4/5">
                     {/* Quick Response Buttons */}
                     <div className="flex flex-row justify-center gap-x-2 md:gap-x-3 items-center text-xs p-2">
-                      <p>{`Pseudonym: ${pseudonym}`}</p>
                       <QuickResponseButton label="Let's move on" icon="😀" />
                       <QuickResponseButton label="That's cool" icon="🌟" />
                       <QuickResponseButton label="I'm confused" icon="😵‍💫" />

--- a/pages/moderator.tsx
+++ b/pages/moderator.tsx
@@ -24,11 +24,7 @@ import {
 } from "../utils";
 
 import { Transcript } from "../components/";
-import { CheckAuthHeader, DefaultEase } from "../utils/Helpers";
-
-export const getServerSideProps = async (context: { req: any }) => {
-  return CheckAuthHeader(context.req.headers);
-};
+import { DefaultEase } from "../utils/Helpers";
 
 function ModeratorScreen({ isAuthenticated }: { isAuthenticated: boolean }) {
   const router = useRouter();

--- a/utils/Decrypt.ts
+++ b/utils/Decrypt.ts
@@ -12,7 +12,7 @@ export default async function decryptCookie(
     if (!token) throw new Error("No token found");
     const secret = new TextEncoder().encode(process.env.SESSION_SECRET!);
     const cookie = await jwtDecrypt(token, secret);
-    return cookie.payload;
+    return cookie;
   } catch (error) {
     console.error("Failed to decrypt cookie:", error);
     return null;

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -278,7 +278,7 @@ export const JoinSession = async (
         accessToken: registerResponse.tokens.access.token,
         refreshToken: registerResponse.tokens.refresh.token,
         // End user session in 1 day
-        expiration: 60 * 60 * 24,
+        expirationFromNow: 60 * 60 * 24,
       }),
     });
 

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -63,6 +63,12 @@ export class Api {
       refresh: null,
     };
   }
+  ClearTokens() {
+    this.API_TOKENS = {
+      access: null,
+      refresh: null,
+    };
+  }
 
   async GetConfig() {
     if (!this.configCache) {

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -277,6 +277,8 @@ export const JoinSession = async (
         userId: registerResponse.user.id,
         accessToken: registerResponse.tokens.access.token,
         refreshToken: registerResponse.tokens.refresh.token,
+        // End user session in 1 day
+        expiration: 60 * 60 * 24,
       }),
     });
 

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -219,12 +219,33 @@ export const SendData = async (
  * On failure, it logs the error and calls the error callback with an error message.
  * @param success - Callback function to call on successful join, with token and pseudonym.
  * @param errorCallback - Callback function to call on error, with an error message.
+ * @param isAuthenticated - Indicating if the user is authenticated.
  */
 export const JoinSession = async (
   success: (result: { userId: string; pseudonym: string }) => void,
-  errorCallback: (err: string) => void
+  errorCallback: (err: string) => void,
+  isAuthenticated?: boolean
 ) => {
   try {
+    // Get existing tokens if authenticated
+    if (isAuthenticated) {
+      const cookieRes = await fetch("/api/cookie");
+      const cookieData = await cookieRes.json();
+
+      if (cookieRes.status === 200 && cookieData.tokens) {
+        // User is already logged in, set tokens and return
+        Api.get().SetTokens(
+          cookieData.tokens.access,
+          cookieData.tokens.refresh
+        );
+        success({
+          userId: cookieData.userId,
+          pseudonym: cookieData.username,
+        });
+        return;
+      }
+    }
+
     // Get new pseudonym for session
     const pseudonymResponse = await RetrieveData("auth/newPseudonym");
 
@@ -237,6 +258,22 @@ export const JoinSession = async (
       registerResponse.tokens.access.token,
       registerResponse.tokens.refresh.token
     );
+
+    // Set session cookie via local API route
+    await fetch("/api/session", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: pseudonymResponse.pseudonym,
+        // Use the access, refresh tokens and userId from the register response
+        userId: registerResponse.user.id,
+        accessToken: registerResponse.tokens.access.token,
+        refreshToken: registerResponse.tokens.refresh.token,
+      }),
+    });
+
     success({
       userId: registerResponse.user.id,
       pseudonym: pseudonymResponse.pseudonym,
@@ -373,8 +410,7 @@ export const createConversationFromData = async (
  * @returns An object containing the isAuthenticated property
  */
 export const CheckAuthHeader = (headers: Record<string, string>) => {
-  const isAuthenticated =
-    headers && headers["x-is-authenticated"] === "true";
+  const isAuthenticated = headers && headers["x-is-authenticated"] === "true";
   return {
     props: {
       isAuthenticated,


### PR DESCRIPTION
## What is in this PR?
This adds support for storing a user's session (pseudonym, ID, tokens) in a cookie to allow for persistent use of the end-user facing parts of the app. The session is valid for one day. On the event assistant page, we are also able to retrieve all message history between the user and the assistant (pending [this](https://github.com/berkmancenter/llm_engine/pull/6) PR).

## Changes in the codebase
- `pages/api/cookie.ts`: new local API route to check if a user has a stored cookie and then decrypt it and return the relevant information
- in `utils/Decrypt.ts`, now return entire cookie instead of just the payload
- store user ID in cookie
- add `isAuthenticated?` bool param to `JoinSession()`, if true get existing tokens from new API route
- in `Api` utils, if 401 response when refreshing tokens, logout local user and clear tokens
- add optional expiry time to API `/session` route when setting cookie

## Documentation and automated testing
Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR
- [ ] start a new conversation or use the ID for an existing one
- [ ] load the backchannel view and see that a cookie is assigned to the local client if you look in devtools -> application -> cookies. It should show as expiring 24 hours from now.
- [ ] send something to the backchannel. You can check what your pseudonym is is by hovering over the green cloud icon.
- [ ] refresh the view and note that your pseudonym is the same.
- [ ] go to the event assistant view, and see that you are writing messages to the assistant as the same pseudonym from backchannel.
- [ ] write some messages to the assistant and wait for responses.
- [ ] refresh the page and see that your DM history is populated.
- [ ] clear the cookie and note that you are assigned a new pseudonym on refresh.
