### PR TITLE
feat: download reports on past events from events view

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,6 +25,16 @@ NEXT_PUBLIC_ABOUT_URL=<VALUE>
 # Example: https://stats.example.com/js/container_XXXXXXXXX.js
 # NEXT_PUBLIC_MATOMO_URL=
 
+# Reporting
+# Auth token for Matomo API access (required if MATOMO_API_URL is set))
+# MATOMO_AUTH_TOKEN=
+
+# Matomo API URL for fetching analytics data (optional, but required for analytics reports)
+# MATOMO_API_URL=
+
+# Matomo Site ID for this application (required if MATOMO_API_URL is set)
+# NEXT_PUBLIC_MATOMO_SITE_ID=
+
 # Analytics: Location Detection
 # Comma-separated list of IP ranges in CIDR notation for detecting local (venue) users
 # Example: LOCAL_IP_RANGES=10.0.0.0/8,192.168.1.0/24,172.16.50.0/24,127.0.0.0/8

--- a/__tests__/utils/eventReportGenerator.test.ts
+++ b/__tests__/utils/eventReportGenerator.test.ts
@@ -1,0 +1,617 @@
+import {
+  generateAndDownloadUserMetricsReport,
+  generateAndDownloadDirectMessageResponsesReport,
+} from "../../utils/eventReportGenerator";
+import { RetrieveData } from "../../utils/Api";
+
+// Mock the dependencies
+jest.mock("../../utils/Api");
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+// Mock DOM APIs
+const mockCreateElement = jest.fn();
+const mockClick = jest.fn();
+const mockAppendChild = jest.fn();
+const mockRemoveChild = jest.fn();
+const mockCreateObjectURL = jest.fn();
+const mockRevokeObjectURL = jest.fn();
+
+describe("eventReportGenerator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup DOM mocks
+    const mockLink = {
+      setAttribute: jest.fn(),
+      click: mockClick,
+      style: {},
+    };
+
+    mockCreateElement.mockReturnValue(mockLink);
+    document.createElement = mockCreateElement;
+    document.body.appendChild = mockAppendChild;
+    document.body.removeChild = mockRemoveChild;
+
+    URL.createObjectURL = mockCreateObjectURL.mockReturnValue("blob:mock-url");
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    // Mock console methods to reduce noise
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("generateAndDownloadUserMetricsReport", () => {
+    const mockConversationId = "test-conversation-123";
+    const mockConversationDate = new Date("2025-11-05T10:00:00Z");
+    const mockMatomoSiteId = "1";
+
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_MATOMO_SITE_ID = mockMatomoSiteId;
+    });
+
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
+    });
+
+    it("should successfully generate and download report with server and Matomo data", async () => {
+      // Mock server report response
+      const serverReportCSV = `Pseudonym,Direct Messages,chat
+user1,5,3
+user2,10,7`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      // Mock Matomo UserId report response
+      const matomoUserData = [
+        { label: "user1", nb_visits: 5, nb_actions: 20 },
+        { label: "user2", nb_visits: 10, nb_actions: 35 },
+      ];
+
+      // Mock Matomo visit details response
+      const matomoVisitDetails = [
+        {
+          userId: "user1",
+          deviceType: "desktop",
+          actionDetails: [
+            {
+              url: `https://example.com/assistant?conversationId=${mockConversationId}&location=local`,
+            },
+          ],
+        },
+        {
+          userId: "user2",
+          deviceType: "mobile",
+          actionDetails: [
+            {
+              url: `https://example.com/assistant?conversationId=${mockConversationId}&location=remote`,
+            },
+          ],
+        },
+      ];
+
+      // Mock fetch for both Matomo calls
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoUserData,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoVisitDetails,
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        mockConversationDate,
+      );
+
+      // Verify server report was fetched
+      expect(RetrieveData).toHaveBeenCalledWith(
+        expect.stringContaining(`conversations/${mockConversationId}/report`),
+        undefined,
+        "text",
+      );
+
+      // Verify Matomo API calls
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // Verify first call (UserId report)
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        "/api/matomo-proxy",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: expect.stringContaining("UserId.getUsers"),
+        }),
+      );
+
+      // Verify second call (visit details)
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        "/api/matomo-proxy",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: expect.stringContaining("Live.getLastVisitsDetails"),
+        }),
+      );
+
+      // Verify CSV download
+      expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+      expect(mockClick).toHaveBeenCalled();
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+
+    it("should generate report without Matomo data when MATOMO_SITE_ID is not configured", async () => {
+      delete process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
+
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5
+user2,10`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        mockConversationDate,
+      );
+
+      // Should fetch server report
+      expect(RetrieveData).toHaveBeenCalled();
+
+      // Should NOT call Matomo API
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      // Should still download CSV
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it("should handle server report fetch failure", async () => {
+      (RetrieveData as jest.Mock).mockResolvedValue({
+        error: true,
+        message: "Failed to fetch report",
+      });
+
+      await expect(
+        generateAndDownloadUserMetricsReport(
+          mockConversationId,
+          mockConversationDate,
+        ),
+      ).rejects.toThrow("Failed to fetch server report");
+
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+
+    it("should handle Matomo API failure gracefully", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      // Mock Matomo API failure
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "Internal server error" }),
+      });
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        mockConversationDate,
+      );
+
+      // Should still download report (without Matomo data)
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it("should combine data from multiple users correctly", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages,chat
+user1,5,3
+user2,10,7
+user3,2,1`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      const matomoUserData = [
+        { label: "user1", nb_visits: 5 },
+        { label: "user2", nb_visits: 10 },
+        // user3 not in Matomo data
+      ];
+
+      const matomoVisitDetails = [
+        {
+          userId: "user1",
+          deviceType: "desktop",
+          actionDetails: [
+            {
+              url: `https://example.com/assistant?conversationId=${mockConversationId}&location=local`,
+            },
+          ],
+        },
+      ];
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoUserData,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoVisitDetails,
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        mockConversationDate,
+      );
+
+      // Verify download was called
+      expect(mockClick).toHaveBeenCalled();
+
+      // Verify Blob was created with combined data
+      const createObjectURLCall = mockCreateObjectURL.mock.calls[0][0];
+      expect(createObjectURLCall).toBeInstanceOf(Blob);
+    });
+
+    it("should use scheduledTime for report date when provided", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      const customDate = new Date("2025-12-25T15:30:00Z");
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        customDate,
+      );
+
+      // Verify Matomo API was called with correct date
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body.params.date).toBe("2025-12-25");
+    });
+
+    it("should filter Matomo visit details by conversationId", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      // Mock visit details with mixed conversation IDs
+      const matomoVisitDetails = [
+        {
+          userId: "user1",
+          deviceType: "desktop",
+          actionDetails: [
+            {
+              url: `https://example.com/assistant?conversationId=${mockConversationId}&location=local`,
+            },
+            {
+              url: `https://example.com/assistant?conversationId=other-conversation&location=local`,
+            },
+          ],
+        },
+      ];
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoVisitDetails,
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        mockConversationDate,
+      );
+
+      // Should successfully process (filtering happens internally)
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it("should aggregate multiple device types per user", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      const matomoVisitDetails = [
+        {
+          userId: "user1",
+          deviceType: "desktop",
+          actionDetails: [
+            {
+              url: `https://example.com/assistant?conversationId=${mockConversationId}&location=local`,
+            },
+          ],
+        },
+        {
+          userId: "user1",
+          deviceType: "mobile",
+          actionDetails: [
+            {
+              url: `https://example.com/assistant?conversationId=${mockConversationId}&location=remote`,
+            },
+          ],
+        },
+      ];
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ label: "user1", nb_visits: 2 }],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoVisitDetails,
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        mockConversationDate,
+      );
+
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it("should handle empty server report", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        mockConversationId,
+        mockConversationDate,
+      );
+
+      // Should still create download
+      expect(mockClick).toHaveBeenCalled();
+    });
+  });
+
+  describe("generateAndDownloadDirectMessageResponsesReport", () => {
+    const mockConversationId = "test-conversation-456";
+
+    it("should successfully generate and download direct message responses report", async () => {
+      const mockTextReport = `Direct Message Responses Report
+     
+User: user1
+Message: Hello
+Response: Hi there!
+
+User: user2
+Message: How are you?
+Response: I'm doing well, thanks!`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(mockTextReport);
+
+      await generateAndDownloadDirectMessageResponsesReport(mockConversationId);
+
+      // Verify API call
+      expect(RetrieveData).toHaveBeenCalledWith(
+        expect.stringContaining(`conversations/${mockConversationId}/report`),
+        undefined,
+        "text",
+      );
+
+      // Verify URL params
+      const callArgs = (RetrieveData as jest.Mock).mock.calls[0][0];
+      expect(callArgs).toContain("reportName=directMessageResponses");
+      expect(callArgs).toContain("format=text");
+
+      // Verify download
+      expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+      expect(mockClick).toHaveBeenCalled();
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+
+      // Verify correct file name
+      const setAttributeCalls = mockCreateElement().setAttribute.mock.calls;
+      const downloadCall = setAttributeCalls.find(
+        (call: any) => call[0] === "download",
+      );
+      expect(downloadCall[1]).toBe(
+        `directMessageResponses_${mockConversationId}.txt`,
+      );
+    });
+
+    it("should handle API failure", async () => {
+      (RetrieveData as jest.Mock).mockResolvedValue({
+        error: true,
+        message: "Failed to fetch report",
+      });
+
+      await expect(
+        generateAndDownloadDirectMessageResponsesReport(mockConversationId),
+      ).rejects.toThrow("Failed to fetch direct message responses report");
+
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+
+    it("should handle unexpected response format", async () => {
+      (RetrieveData as jest.Mock).mockResolvedValue({ unexpected: "format" });
+
+      await expect(
+        generateAndDownloadDirectMessageResponsesReport(mockConversationId),
+      ).rejects.toThrow("Unexpected response format");
+
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+
+    it("should handle network errors", async () => {
+      (RetrieveData as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+      await expect(
+        generateAndDownloadDirectMessageResponsesReport(mockConversationId),
+      ).rejects.toThrow("Network error");
+
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+
+    it("should create text file with correct MIME type", async () => {
+      const mockTextReport = "Sample report content";
+
+      (RetrieveData as jest.Mock).mockResolvedValue(mockTextReport);
+
+      await generateAndDownloadDirectMessageResponsesReport(mockConversationId);
+
+      // Verify Blob was created with correct type
+      const blobCall = mockCreateObjectURL.mock.calls[0][0];
+      expect(blobCall.type).toBe("text/plain;charset=utf-8;");
+    });
+  });
+
+  describe("CSV parsing and generation", () => {
+    it("should correctly parse CSV with multiple columns", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages,chat,email
+user1,5,3,2
+user2,10,7,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        "test-conv",
+        new Date("2025-11-05"),
+      );
+
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it("should handle CSV with missing values", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages,chat
+user1,,3
+user2,10,`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        "test-conv",
+        new Date("2025-11-05"),
+      );
+
+      expect(mockClick).toHaveBeenCalled();
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle users in Matomo but not in server report", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      const matomoUserData = [
+        { label: "user1", nb_visits: 5 },
+        { label: "user2", nb_visits: 3 }, // Not in server report
+      ];
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoUserData,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        "test-conv",
+        new Date("2025-11-05"),
+      );
+
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it("should handle both local and remote location types for same user", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      const matomoVisitDetails = [
+        {
+          userId: "user1",
+          deviceType: "desktop",
+          actionDetails: [
+            {
+              url: "https://example.com/assistant?conversationId=test-conv&location=local",
+            },
+            {
+              url: "https://example.com/assistant?conversationId=test-conv&location=remote",
+            },
+          ],
+        },
+      ];
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => matomoVisitDetails,
+        });
+
+      await generateAndDownloadUserMetricsReport(
+        "test-conv",
+        new Date("2025-11-05"),
+      );
+
+      expect(mockClick).toHaveBeenCalled();
+    });
+
+    it("should use today's date when conversationDate is not provided", async () => {
+      const serverReportCSV = `Pseudonym,Direct Messages
+user1,5`;
+
+      (RetrieveData as jest.Mock).mockResolvedValue(serverReportCSV);
+
+      await generateAndDownloadUserMetricsReport("test-conv");
+
+      expect(mockClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/pages/api/matomo-proxy.ts
+++ b/pages/api/matomo-proxy.ts
@@ -1,0 +1,66 @@
+/**
+ * Proxy API route for Matomo requests
+ */
+
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { params } = req.body;
+
+  if (!params) {
+    return res.status(400).json({ error: "Missing params" });
+  }
+
+  // Get Matomo configuration from environment variables (server-side only)
+  const matomoUrl = process.env.MATOMO_API_URL;
+  const matomoAuthToken = process.env.MATOMO_AUTH_TOKEN;
+
+  if (!matomoUrl || !matomoAuthToken) {
+    return res.status(500).json({
+      error: "Matomo configuration not found",
+      message: "MATOMO_API_URL and MATOMO_AUTH_TOKEN must be set",
+    });
+  }
+
+  // Add auth token to params
+  const urlParams = new URLSearchParams(params);
+  urlParams.set("token_auth", matomoAuthToken);
+
+  try {
+    const response = await fetch(`${matomoUrl}/index.php`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: urlParams.toString(),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(
+        `Matomo proxy request failed with status ${response.status}: ${errorText}`,
+      );
+      return res.status(response.status).json({
+        error: "Matomo request failed",
+        status: response.status,
+        message: errorText,
+      });
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error: any) {
+    console.error("Matomo proxy error:", error);
+    return res.status(500).json({
+      error: "Internal server error",
+      message: error.message,
+    });
+  }
+}

--- a/utils/eventReportGenerator.ts
+++ b/utils/eventReportGenerator.ts
@@ -1,0 +1,532 @@
+/**
+ * Browser-compatible utility functions for generating user metrics reports
+ * Combines server data with Matomo analytics
+ */
+
+import { RetrieveData } from "./Api";
+
+interface MatomoUserData {
+  label: string; // userId/pseudonym
+  [key: string]: string | number; // Dynamic columns from Matomo
+}
+
+interface ServerReportData {
+  pseudonym: string;
+  directMessages: string | number;
+  [key: string]: string | number; // Additional channel columns
+}
+
+/**
+ * Fetch detailed visit information including device types and location types (local/remote) per user
+ */
+async function fetchMatomoVisitDetails(
+  siteId: string,
+  conversationDate: Date,
+  conversationId: string,
+): Promise<Map<
+  string,
+  { deviceTypes: Set<string>; locationTypes: Set<string> }
+> | null> {
+  if (!siteId || !conversationId) {
+    return null;
+  }
+
+  const segment = `pageUrl=@assistant?conversationId=${conversationId}`;
+
+  try {
+    const formatDate = (date: Date) => date.toISOString().split("T")[0];
+
+    const params: Record<string, string> = {
+      module: "API",
+      method: "Live.getLastVisitsDetails",
+      idSite: siteId,
+      period: "day",
+      date: formatDate(conversationDate),
+      segment,
+      format: "JSON",
+      filter_limit: "-1",
+    };
+
+    console.log(
+      `Fetching Matomo visit details for conversationId: ${conversationId}`,
+    );
+
+    const response = await fetch("/api/matomo-proxy", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ params }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      console.error(
+        `Matomo visit details request failed with status ${response.status}:`,
+        errorData,
+      );
+      return null;
+    }
+
+    const visits = (await response.json()) as any[];
+
+    // Aggregate device types and location types per user
+    const userDetails = new Map<
+      string,
+      { deviceTypes: Set<string>; locationTypes: Set<string> }
+    >();
+
+    for (const visit of visits) {
+      if (!visit.userId) continue;
+
+      // Check if this visit accessed the specific conversation
+      let hasRelevantAction = false;
+      const locationTypesForConversation = new Set<string>();
+
+      // Extract location types from action details, filtering for this specific conversation
+      if (visit.actionDetails && Array.isArray(visit.actionDetails)) {
+        for (const action of visit.actionDetails) {
+          if (
+            action.url &&
+            action.url.includes(`assistant?conversationId=${conversationId}`)
+          ) {
+            hasRelevantAction = true;
+
+            // Categorize as local or remote
+            if (action.url.includes("location=local")) {
+              locationTypesForConversation.add("local");
+            } else {
+              locationTypesForConversation.add("remote");
+            }
+          }
+        }
+      }
+
+      // Only add device type if this visit actually accessed this specific conversation
+      if (hasRelevantAction) {
+        if (!userDetails.has(visit.userId)) {
+          userDetails.set(visit.userId, {
+            deviceTypes: new Set<string>(),
+            locationTypes: new Set<string>(),
+          });
+        }
+
+        const details = userDetails.get(visit.userId)!;
+
+        // Add device type only if we found relevant actions
+        if (visit.deviceType) {
+          details.deviceTypes.add(visit.deviceType);
+        }
+
+        // Add location types
+        for (const locationType of locationTypesForConversation) {
+          details.locationTypes.add(locationType);
+        }
+      }
+    }
+
+    console.log(
+      `Aggregated device/location data for ${userDetails.size} users from ${visits.length} visits`,
+    );
+    return userDetails;
+  } catch (error: any) {
+    console.error(`Error fetching Matomo visit details: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Fetch Matomo UserId report for a specific conversation ID
+ */
+async function fetchMatomoUserIdReport(
+  siteId: string,
+  conversationDate: Date,
+  conversationId: string,
+): Promise<{ data: MatomoUserData[]; columns: string[] } | null> {
+  if (!siteId || !conversationId) {
+    console.log("Matomo configuration incomplete, skipping Matomo data fetch");
+    return null;
+  }
+
+  // Construct segment to filter for URLs containing 'assistant?conversationId=...'
+  const segment = `pageUrl=@assistant?conversationId=${conversationId}`;
+
+  try {
+    const formatDate = (date: Date) => date.toISOString().split("T")[0];
+
+    const params: Record<string, string> = {
+      module: "API",
+      method: "UserId.getUsers",
+      idSite: siteId,
+      period: "day",
+      date: formatDate(conversationDate),
+      segment,
+      format: "JSON",
+      filter_limit: "-1", // Get all rows
+    };
+
+    console.log(
+      `Fetching Matomo UserId report for date ${formatDate(conversationDate)} for conversationId: ${conversationId}`,
+    );
+
+    const response = await fetch("/api/matomo-proxy", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ params }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      console.error(
+        `Matomo API request failed with status ${response.status}:`,
+        errorData,
+      );
+      return null;
+    }
+
+    const data = (await response.json()) as MatomoUserData[];
+
+    if (!Array.isArray(data) || data.length === 0) {
+      console.log("No Matomo data returned");
+      return { data: [], columns: [] };
+    }
+
+    // Extract column names from the first row (excluding 'label' which is the userId)
+    const columns = Object.keys(data[0]).filter((key) => key !== "label");
+
+    console.log(
+      `Fetched ${data.length} user records from Matomo with ${columns.length} metrics`,
+    );
+
+    return { data, columns };
+  } catch (error: any) {
+    console.error(`Error fetching Matomo data: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Parse CSV string into array of objects
+ */
+function parseCSV(csvString: string): ServerReportData[] {
+  const lines = csvString.trim().split("\n");
+  if (lines.length === 0) return [];
+
+  const headers = lines[0].split(",");
+  const data: ServerReportData[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = lines[i].split(",");
+    const row: ServerReportData = { pseudonym: "", directMessages: "" };
+
+    for (let j = 0; j < headers.length; j++) {
+      const header = headers[j].toLowerCase().replace(/\s+/g, "");
+      if (header === "pseudonym") {
+        row.pseudonym = values[j];
+      } else if (header === "directmessages") {
+        row.directMessages = values[j];
+      } else {
+        row[headers[j]] = values[j];
+      }
+    }
+
+    data.push(row);
+  }
+
+  return data;
+}
+
+/**
+ * Fetch user metrics report from the backend
+ */
+async function fetchUserMetricsReport(
+  conversationId: string,
+): Promise<string | null> {
+  try {
+    const params = new URLSearchParams({
+      reportName: "userMetrics",
+      format: "csv",
+      additionalChannels: "chat",
+      agent: "eventAssistantPlus",
+    });
+
+    const urlSuffix = `conversations/${conversationId}/report?${params.toString()}`;
+    console.log(`Fetching user metrics report for conversation: ${conversationId}`);
+
+    const response = await RetrieveData(urlSuffix, undefined, "text");
+
+    if (response && typeof response === "object" && "error" in response) {
+      console.error(
+        `Failed to fetch user metrics report:`,
+        response.message,
+      );
+      return null;
+    }
+
+    return response as string;
+  } catch (error: any) {
+    console.error(`Error fetching user metrics report: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Combine server data with Matomo data and generate CSV
+ */
+function generateCombinedCSV(
+  serverData: ServerReportData[],
+  matomoData: MatomoUserData[] | null,
+  matomoColumns: string[] | null,
+  matomoDeviceTypes: Map<
+    string,
+    { deviceTypes: Set<string>; locationTypes: Set<string> }
+  > | null,
+): string {
+  // Create a map of pseudonym -> Matomo metrics for quick lookup
+  const matomoMap = new Map<string, MatomoUserData>();
+  if (matomoData) {
+    for (const row of matomoData) {
+      matomoMap.set(row.label, row);
+    }
+  }
+
+  // Get all unique pseudonyms from both sources
+  const allPseudonyms = new Set<string>();
+  serverData.forEach((row) => allPseudonyms.add(row.pseudonym));
+  if (matomoData) {
+    matomoData.forEach((row) => allPseudonyms.add(row.label));
+  }
+  if (matomoDeviceTypes) {
+    Array.from(matomoDeviceTypes.keys()).forEach((pseudonym) =>
+      allPseudonyms.add(pseudonym),
+    );
+  }
+
+  const pseudonyms = Array.from(allPseudonyms).sort();
+
+  // Get additional channel names from server data (all columns except Pseudonym and Direct Messages)
+  const additionalChannels: string[] = [];
+  if (serverData.length > 0) {
+    const firstRow = serverData[0];
+    Object.keys(firstRow).forEach((key) => {
+      if (key !== "pseudonym" && key !== "directMessages") {
+        additionalChannels.push(key);
+      }
+    });
+  }
+
+  // Build headers: Pseudonym, [Matomo columns], Device Types, Location Types, Direct Messages, [Additional channels]
+  const headers = [
+    "Pseudonym",
+    ...(matomoColumns || []),
+    ...(matomoDeviceTypes ? ["Device Types", "Location Types"] : []),
+    "Direct Messages",
+    ...additionalChannels,
+  ];
+
+  const rows = [headers.join(",")];
+
+  // Create lookup map for server data
+  const serverDataMap = new Map<string, ServerReportData>();
+  serverData.forEach((row) => serverDataMap.set(row.pseudonym, row));
+
+  // Build data rows
+  for (const pseudonym of pseudonyms) {
+    const rowValues: (string | number)[] = [pseudonym];
+
+    // Add Matomo metrics
+    if (matomoColumns) {
+      const matomoRow = matomoMap.get(pseudonym);
+      for (const column of matomoColumns) {
+        rowValues.push(matomoRow?.[column] ?? "");
+      }
+    }
+
+    // Add device types and location types
+    if (matomoDeviceTypes) {
+      const details = matomoDeviceTypes.get(pseudonym);
+      rowValues.push(
+        details?.deviceTypes ? Array.from(details.deviceTypes).join("; ") : "",
+      );
+      rowValues.push(
+        details?.locationTypes
+          ? Array.from(details.locationTypes).join("; ")
+          : "",
+      );
+    }
+
+    // Add direct message count from server data
+    const serverRow = serverDataMap.get(pseudonym);
+    rowValues.push(serverRow?.directMessages ?? "");
+
+    // Add additional channel counts
+    for (const channel of additionalChannels) {
+      rowValues.push(serverRow?.[channel] ?? "");
+    }
+
+    rows.push(rowValues.join(","));
+  }
+
+  return rows.join("\n");
+}
+
+/**
+ * Download a CSV file in the browser
+ */
+function downloadCSV(csvContent: string, fileName: string) {
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const link = document.createElement("a");
+  const url = URL.createObjectURL(blob);
+
+  link.setAttribute("href", url);
+  link.setAttribute("download", fileName);
+  link.style.visibility = "hidden";
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Main function to generate and download user metrics report
+ */
+export async function generateAndDownloadUserMetricsReport(
+  conversationId: string,
+  conversationDate?: Date,
+): Promise<void> {
+  try {
+    // Parse report date or use today
+    const reportDate = conversationDate || new Date();
+
+    // Get Matomo Site ID from environment variables
+    const matomoSiteId = process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
+
+    console.log(
+      `Generating user metrics report for conversation ${conversationId}`,
+    );
+    console.log(`Using report date: ${reportDate.toISOString().split("T")[0]}`);
+
+    // Fetch server report
+    const serverReportCSV = await fetchUserMetricsReport(conversationId);
+    if (!serverReportCSV) {
+      throw new Error("Failed to fetch server report");
+    }
+
+    // Parse server report
+    const serverData = parseCSV(serverReportCSV);
+    console.log(`Parsed ${serverData.length} rows from server report`);
+
+    // Fetch Matomo data if configured
+    let matomoResult: { data: MatomoUserData[]; columns: string[] } | null =
+      null;
+    let matomoVisitDetails: Map<
+      string,
+      { deviceTypes: Set<string>; locationTypes: Set<string> }
+    > | null = null;
+
+    if (matomoSiteId) {
+      matomoResult = await fetchMatomoUserIdReport(
+        matomoSiteId,
+        reportDate,
+        conversationId,
+      );
+
+      matomoVisitDetails = await fetchMatomoVisitDetails(
+        matomoSiteId,
+        reportDate,
+        conversationId,
+      );
+    } else {
+      console.log(
+        "Matomo configuration not found, generating report without Matomo data",
+      );
+    }
+
+    // Generate combined CSV
+    const combinedCSV = generateCombinedCSV(
+      serverData,
+      matomoResult?.data || null,
+      matomoResult?.columns || null,
+      matomoVisitDetails,
+    );
+
+    // Download the file
+    const outputFileName = `userMetrics_${conversationId}.csv`;
+    downloadCSV(combinedCSV, outputFileName);
+
+    console.log(`\nReport generated successfully: ${outputFileName}`);
+    console.log(`Total users: ${serverData.length}`);
+    if (matomoResult) {
+      console.log(`Matomo data included for ${matomoResult.data.length} users`);
+    }
+  } catch (error: any) {
+    console.error("Error generating report:", error);
+    throw error;
+  }
+}
+
+/**
+ * Download a text file in the browser
+ */
+function downloadText(textContent: string, fileName: string) {
+  const blob = new Blob([textContent], { type: "text/plain;charset=utf-8;" });
+  const link = document.createElement("a");
+  const url = URL.createObjectURL(blob);
+
+  link.setAttribute("href", url);
+  link.setAttribute("download", fileName);
+  link.style.visibility = "hidden";
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Generate and download direct message responses report
+ */
+export async function generateAndDownloadDirectMessageResponsesReport(
+  conversationId: string,
+): Promise<void> {
+  try {
+    const params = new URLSearchParams({
+      reportName: "directMessageResponses",
+      format: "text",
+      additionalChannels: "chat",
+    });
+
+    const urlSuffix = `conversations/${conversationId}/report?${params.toString()}`;
+    console.log(
+      `Fetching direct message responses report for conversation: ${conversationId}`,
+    );
+
+    const response = await RetrieveData(urlSuffix, undefined, "text");
+
+    if (response && typeof response === "object" && "error" in response) {
+      console.error(
+        `Failed to fetch direct message responses report:`,
+        response.message,
+      );
+      throw new Error("Failed to fetch direct message responses report");
+    }
+
+    if (typeof response === "string") {
+      const outputFileName = `directMessageResponses_${conversationId}.txt`;
+      downloadText(response, outputFileName);
+      console.log(
+        `Direct message responses report generated successfully: ${outputFileName}`,
+      );
+    } else {
+      throw new Error("Unexpected response format");
+    }
+  } catch (error: any) {
+    console.error("Error generating direct message responses report:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## What is in this PR?

This PR adds a download button to the events page to download two reports for past events:
- directMessagesReport from the server - text report with aggregate statistics and a detailed printout of all exchanges between users and agents on direct channels and the group chat channel
- userMetricsReport - csv file of message counts per pseudonym from the server, combined with Matomo userId report segmented by the assistant page URL, conversation Id, and date of the conversation (when MATOMO connection env variables provided)

## Changes in the codebase
- New server code that uses Matomo API to fetch data (to avoid browser CORS issues)
- New button on UI as described above - downloads two files, the csv and text reports.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [x] update team documentation of any new or changed environment variables?

## Testing this PR

Note this requires back-end code from PR: https://github.com/berkmancenter/llm_engine/pull/31

- [ ] Create an auth token in Matomo - Settings->Personal->Security
- [ ] Set `MATOMO_AUTH_TOKEN` to this in `.env`
- [ ] Add MATOMO_API_URL and NEXT_PUBLIC_MATOMO_SITE_ID vars (see team doc for values)
- [ ] Display /admin/events. You should see the download button for all past events (regardless of owner)
- [ ] Download report for an EA or EAP conversation. You should have a .csv and a .txt in downloads. Open and verify they look correct. If Matomo data was successfully retrieved, the csv file should have several columns merged from Mataomo, like nb_actions, etc


## Additional information

This button will be present for other types of conversations like backChannel, but won't be valid. Will open ticket to allow for download of periodic reports and choose reports by conversation type.
