### PR TITLE
feat: show messages from Enagement Agent as from Event Assistant

### DIFF
--- a/__tests__/components/GroupChatPanel.test.tsx
+++ b/__tests__/components/GroupChatPanel.test.tsx
@@ -107,7 +107,7 @@ describe("GroupChatPanel", () => {
     ];
 
     const { container } = render(
-      <GroupChatPanel {...baseProps} messages={messages} />
+      <GroupChatPanel {...baseProps} messages={messages} />,
     );
 
     // Should NOT show animated SVG loading indicator in chat mode
@@ -134,11 +134,11 @@ describe("GroupChatPanel", () => {
     ];
 
     const { container } = render(
-      <GroupChatPanel {...baseProps} messages={messages} />
+      <GroupChatPanel {...baseProps} messages={messages} />,
     );
 
     // Check that mention has styling with font-semibold class
-    const mentionSpan = container.querySelector('.font-semibold');
+    const mentionSpan = container.querySelector(".font-semibold");
     expect(mentionSpan).toBeInTheDocument();
     expect(mentionSpan?.textContent).toContain("@Bob");
   });
@@ -197,7 +197,7 @@ describe("GroupChatPanel", () => {
 
   it("scrolls to bottom when new messages arrive", async () => {
     const { rerender, container } = render(
-      <GroupChatPanel {...baseProps} messages={[]} />
+      <GroupChatPanel {...baseProps} messages={[]} />,
     );
 
     // Get the scrollable messages container
@@ -358,6 +358,30 @@ describe("GroupChatPanel", () => {
     expect(screen.queryByText("Event Mediator Plus")).not.toBeInTheDocument();
   });
 
+  it("normalizes 'Engagement Agent' to 'Event Assistant'", () => {
+    const messages = [
+      {
+        id: "1",
+        pseudonym: "Engagement Agent",
+        createdAt: "2025-10-17T12:00:00Z",
+        body: { text: "Hello" },
+        channels: ["chat"],
+        conversation: "conv-1",
+        pseudonymId: "em-plus-1",
+        fromAgent: true,
+        pause: false,
+        visible: true,
+        upVotes: [],
+        downVotes: [],
+      },
+    ];
+
+    render(<GroupChatPanel {...baseProps} messages={messages} />);
+
+    expect(screen.getByText("Event Assistant")).toBeInTheDocument();
+    expect(screen.queryByText("Enagement Agent")).not.toBeInTheDocument();
+  });
+
   it("applies assistant avatar and background color to Event Assistant messages", () => {
     const messages = [
       {
@@ -376,15 +400,17 @@ describe("GroupChatPanel", () => {
       },
     ];
 
-    const { container } = render(<GroupChatPanel {...baseProps} messages={messages} />);
+    const { container } = render(
+      <GroupChatPanel {...baseProps} messages={messages} />,
+    );
 
     // Check that the avatar has the purple background color (#DDD6FE)
-    const avatar = container.querySelector('.rounded-full');
-    expect(avatar).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const avatar = container.querySelector(".rounded-full");
+    expect(avatar).toHaveStyle({ backgroundColor: "#DDD6FE" });
 
     // Check that the message bubble has the purple background color (#DDD6FE)
-    const messageBubble = container.querySelector('.rounded-2xl');
-    expect(messageBubble).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const messageBubble = container.querySelector(".rounded-2xl");
+    expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
   });
 
   it("applies assistant avatar and background color to Event Assistant Plus messages", () => {
@@ -405,15 +431,17 @@ describe("GroupChatPanel", () => {
       },
     ];
 
-    const { container } = render(<GroupChatPanel {...baseProps} messages={messages} />);
+    const { container } = render(
+      <GroupChatPanel {...baseProps} messages={messages} />,
+    );
 
     // Check that the avatar has the purple background color (#DDD6FE)
-    const avatar = container.querySelector('.rounded-full');
-    expect(avatar).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const avatar = container.querySelector(".rounded-full");
+    expect(avatar).toHaveStyle({ backgroundColor: "#DDD6FE" });
 
     // Check that the message bubble has the purple background color (#DDD6FE)
-    const messageBubble = container.querySelector('.rounded-2xl');
-    expect(messageBubble).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const messageBubble = container.querySelector(".rounded-2xl");
+    expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
   });
 
   it("applies assistant avatar and background color to Event Mediator messages", () => {
@@ -434,15 +462,17 @@ describe("GroupChatPanel", () => {
       },
     ];
 
-    const { container } = render(<GroupChatPanel {...baseProps} messages={messages} />);
+    const { container } = render(
+      <GroupChatPanel {...baseProps} messages={messages} />,
+    );
 
     // Check that the avatar has the purple background color (#DDD6FE)
-    const avatar = container.querySelector('.rounded-full');
-    expect(avatar).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const avatar = container.querySelector(".rounded-full");
+    expect(avatar).toHaveStyle({ backgroundColor: "#DDD6FE" });
 
     // Check that the message bubble has the purple background color (#DDD6FE)
-    const messageBubble = container.querySelector('.rounded-2xl');
-    expect(messageBubble).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const messageBubble = container.querySelector(".rounded-2xl");
+    expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
   });
 
   it("applies assistant avatar and background color to Event Mediator Plus messages", () => {
@@ -463,15 +493,17 @@ describe("GroupChatPanel", () => {
       },
     ];
 
-    const { container } = render(<GroupChatPanel {...baseProps} messages={messages} />);
+    const { container } = render(
+      <GroupChatPanel {...baseProps} messages={messages} />,
+    );
 
     // Check that the avatar has the purple background color (#DDD6FE)
-    const avatar = container.querySelector('.rounded-full');
-    expect(avatar).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const avatar = container.querySelector(".rounded-full");
+    expect(avatar).toHaveStyle({ backgroundColor: "#DDD6FE" });
 
     // Check that the message bubble has the purple background color (#DDD6FE)
-    const messageBubble = container.querySelector('.rounded-2xl');
-    expect(messageBubble).toHaveStyle({ backgroundColor: '#DDD6FE' });
+    const messageBubble = container.querySelector(".rounded-2xl");
+    expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
   });
 
   it("normalizes 'Event Assistant Plus' to 'Event Assistant' in contributors for mentions", () => {
@@ -534,7 +566,7 @@ describe("GroupChatPanel", () => {
       ];
 
       const { container } = render(
-        <GroupChatPanel {...baseProps} messages={messages} />
+        <GroupChatPanel {...baseProps} messages={messages} />,
       );
 
       // Check timestamp is displayed
@@ -575,7 +607,7 @@ describe("GroupChatPanel", () => {
       ];
 
       const { container } = render(
-        <GroupChatPanel {...baseProps} messages={messages} />
+        <GroupChatPanel {...baseProps} messages={messages} />,
       );
 
       // Should show two timestamps (one for each different minute)
@@ -616,7 +648,7 @@ describe("GroupChatPanel", () => {
       ];
 
       const { container } = render(
-        <GroupChatPanel {...baseProps} messages={messages} />
+        <GroupChatPanel {...baseProps} messages={messages} />,
       );
 
       // Should show two timestamps (one for each different hour)
@@ -657,7 +689,7 @@ describe("GroupChatPanel", () => {
       ];
 
       const { container } = render(
-        <GroupChatPanel {...baseProps} messages={messages} />
+        <GroupChatPanel {...baseProps} messages={messages} />,
       );
 
       // Should only show one timestamp (for the first message)
@@ -698,7 +730,7 @@ describe("GroupChatPanel", () => {
       ];
 
       const { container } = render(
-        <GroupChatPanel {...baseProps} messages={messages} />
+        <GroupChatPanel {...baseProps} messages={messages} />,
       );
 
       // Should show two timestamps (one for each different minute)

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -110,7 +110,7 @@ export class Api {
 export const GetChannelPasscode = (
   channel: string,
   query: ParsedUrlQuery,
-  setErrorMessage: (err: string) => void
+  setErrorMessage: (err: string) => void,
 ) => {
   let hasChannel = false;
   let passcodeParam = null;
@@ -160,10 +160,10 @@ export const SendData = async (
   urlSuffix: string,
   payload: any,
   accessToken?: string,
-  fetchOptions?: RequestInit
+  fetchOptions?: RequestInit,
 ) => {
   const API_TOKENS = Api.get().GetTokens();
-  
+
   let options: RequestInit = fetchOptions || {
     method: "POST",
     headers: {
@@ -171,12 +171,12 @@ export const SendData = async (
     },
     body: JSON.stringify(payload),
   };
-  
+
   // Ensure headers is a mutable object
   if (!options.headers) {
     options.headers = {};
   }
-  
+
   // Add Authorization header; use provided accessToken if available
   (options.headers as Record<string, string>)["Authorization"] = accessToken
     ? `Bearer ${accessToken}`
@@ -186,7 +186,7 @@ export const SendData = async (
     const response = await fetchWithTokenRefresh(
       `${process.env.NEXT_PUBLIC_API_URL}/${urlSuffix}`,
       options,
-      !accessToken // Use stored tokens if no explicit accessToken provided
+      !accessToken, // Use stored tokens if no explicit accessToken provided
     );
 
     // TODO: Handle other status codes as needed
@@ -200,7 +200,10 @@ export const SendData = async (
     }
 
     // Handle responses with no content (204 or empty body)
-    if (response.status === 204 || response.headers.get("Content-Length") === "0") {
+    if (
+      response.status === 204 ||
+      response.headers.get("Content-Length") === "0"
+    ) {
       return { success: true };
     }
 
@@ -210,7 +213,6 @@ export const SendData = async (
     console.error("There was a problem with the send operation:", error);
   }
 };
-
 
 // Default easing class for animations
 export const DefaultEase = " ease-[cubic-bezier(0.075, 0.820, 0.165, 1.000)]";
@@ -223,11 +225,11 @@ export const DefaultEase = " ease-[cubic-bezier(0.075, 0.820, 0.165, 1.000)]";
  */
 async function getTypeForConversation(
   conversation: components["schemas"]["Conversation"],
-  conversationTypes: components["schemas"]["ConversationType"][]
+  conversationTypes: components["schemas"]["ConversationType"][],
 ): Promise<components["schemas"]["ConversationType"]> {
   if (conversation.conversationType) {
     const type = conversationTypes.find(
-      (type) => type.name === conversation.conversationType
+      (type) => type.name === conversation.conversationType,
     );
     if (type) return type;
   }
@@ -236,7 +238,7 @@ async function getTypeForConversation(
   // backChannel and eventAssistant conversation types match their agent names
   // (both backChannelInsights and backChannelMetrics contain 'backChannel', the type name)
   return conversationTypes.find((convType) =>
-    agentNames.some((agentName) => agentName.includes(convType.name))
+    agentNames.some((agentName) => agentName.includes(convType.name)),
   )!;
 }
 
@@ -246,7 +248,7 @@ function generateEventUrls(conversationData: Conversation): EventUrls {
   const participant: EventUrl[] = [];
 
   const zoomAdapter = conversationData.adapters.find(
-    (adapter) => adapter.type === "zoom"
+    (adapter) => adapter.type === "zoom",
   );
   const zoom = zoomAdapter
     ? { label: "Zoom", url: zoomAdapter.config?.meetingUrl as string }
@@ -255,17 +257,17 @@ function generateEventUrls(conversationData: Conversation): EventUrls {
   const convType = conversationData.type;
 
   const transcriptPasscode = conversationData.channels.find(
-    (channel) => channel.name === "transcript"
+    (channel) => channel.name === "transcript",
   )?.passcode;
   const hasTranscript = Boolean(transcriptPasscode);
 
   const chatPasscode = conversationData.channels.find(
-    (channel) => channel.name === "chat"
+    (channel) => channel.name === "chat",
   )?.passcode;
   const hasChat = Boolean(chatPasscode);
 
   const modPasscode = conversationData.channels.find(
-    (channel) => channel.name === "moderator"
+    (channel) => channel.name === "moderator",
   )?.passcode;
 
   const modUrl = modPasscode
@@ -278,7 +280,7 @@ function generateEventUrls(conversationData: Conversation): EventUrls {
 
   if (convType && convType.name === "backChannel") {
     const participantPasscode = conversationData.channels.find(
-      (channel) => channel.name === "participant"
+      (channel) => channel.name === "participant",
     )?.passcode;
 
     if (participantPasscode) {
@@ -325,13 +327,13 @@ function generateEventUrls(conversationData: Conversation): EventUrls {
 }
 
 export const getConversation = async (
-  id: string
+  id: string,
 ): Promise<Conversation | null> => {
   const response = await Request(`conversations/${id}`);
   if (response && "error" in response) {
     console.error(
       `Error fetching conversation data for ID ${id}:`,
-      response.message
+      response.message,
     );
     return null;
   }
@@ -339,7 +341,7 @@ export const getConversation = async (
 };
 
 export const createConversationFromData = async (
-  data: components["schemas"]["Conversation"]
+  data: components["schemas"]["Conversation"],
 ): Promise<Conversation> => {
   const { conversationTypes, availablePlatforms } = await Api.get().GetConfig();
 
@@ -354,7 +356,7 @@ export const createConversationFromData = async (
     type,
     eventUrls,
     platformTypes: availablePlatforms.filter((platform) =>
-      data.platforms?.some((p) => p === platform.name)
+      data.platforms?.some((p) => p === platform.name),
     ),
   };
 };
@@ -364,7 +366,8 @@ export const createConversationFromData = async (
  * @returns An object containing the authType property
  */
 export const CheckAuthHeader = (headers: Record<string, string>) => {
-  const authType = headers && headers["x-auth-type"] ? headers["x-auth-type"] : "guest";
+  const authType =
+    headers && headers["x-auth-type"] ? headers["x-auth-type"] : "guest";
   return {
     props: {
       authType,
@@ -377,13 +380,16 @@ export const CheckAuthHeader = (headers: Record<string, string>) => {
  * @param pseudonym - The pseudonym to check
  * @returns true if the pseudonym is an Event Assistant variant
  */
-export const isAssistantPseudonym = (pseudonym: string | null | undefined): boolean => {
+export const isAssistantPseudonym = (
+  pseudonym: string | null | undefined,
+): boolean => {
   if (!pseudonym) return false;
   return (
     pseudonym === "Event Assistant" ||
     pseudonym === "Event Assistant Plus" ||
     pseudonym === "Event Mediator" ||
-    pseudonym === "Event Mediator Plus"
+    pseudonym === "Event Mediator Plus" ||
+    pseudonym === "Engagement Agent"
   );
 };
 
@@ -392,7 +398,9 @@ export const isAssistantPseudonym = (pseudonym: string | null | undefined): bool
  * @param pseudonym - The pseudonym to normalize
  * @returns "Event Assistant" if the pseudonym is a variant, otherwise the original pseudonym
  */
-export const normalizeAssistantPseudonym = (pseudonym: string | null | undefined): string => {
+export const normalizeAssistantPseudonym = (
+  pseudonym: string | null | undefined,
+): string => {
   if (!pseudonym) return "";
   return isAssistantPseudonym(pseudonym) ? "Event Assistant" : pseudonym;
 };


### PR DESCRIPTION


## What is in this PR?

Normalize new agent type message sender

## Changes in the codebase

- Small change to include the Engagement Agent pseudonym in the logic to determine if assistant.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR



- [ ] Test in conjunction with https://github.com/berkmancenter/llm_engine/pull/32 and verify messages come from 'Event Assistant'



## Additional information

Will open a ticket to just use 'Event Assistant' for all agent types in the conversation type, so we don't have to keep doing this in the future if we change internal agent names.
