### PR TITLE
feat: add lightbox to render image and mindmap responses on assistant page

### DIFF
--- a/__tests__/components/MarkmapView.test.tsx
+++ b/__tests__/components/MarkmapView.test.tsx
@@ -38,34 +38,47 @@ describe("MarkmapView Component", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Mock getBoundingClientRect to return valid dimensions for SVG
+    Element.prototype.getBoundingClientRect = jest.fn(() => ({
+      width: 800,
+      height: 400,
+      top: 0,
+      left: 0,
+      bottom: 400,
+      right: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }));
   });
 
   it("renders the component with controls", () => {
     render(<MarkmapView markdown={sampleMarkdown} />);
 
-    expect(screen.getByLabelText("Zoom out")).toBeInTheDocument();
-    expect(screen.getByLabelText("Fit to container")).toBeInTheDocument();
-    expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
+    expect(screen.getByLabelText("Zoom out mind map")).toBeInTheDocument();
+    expect(screen.getByLabelText("Fit mind map to container")).toBeInTheDocument();
+    expect(screen.getByLabelText("Zoom in mind map")).toBeInTheDocument();
   });
 
   it("renders zoom out button with minus sign", () => {
     render(<MarkmapView markdown={sampleMarkdown} />);
 
-    const zoomOutButton = screen.getByLabelText("Zoom out");
+    const zoomOutButton = screen.getByLabelText("Zoom out mind map");
     expect(zoomOutButton).toHaveTextContent("−");
   });
 
   it("renders fit button", () => {
     render(<MarkmapView markdown={sampleMarkdown} />);
 
-    const fitButton = screen.getByLabelText("Fit to container");
+    const fitButton = screen.getByLabelText("Fit mind map to container");
     expect(fitButton).toHaveTextContent("fit");
   });
 
   it("renders zoom in button with plus sign", () => {
     render(<MarkmapView markdown={sampleMarkdown} />);
 
-    const zoomInButton = screen.getByLabelText("Zoom in");
+    const zoomInButton = screen.getByLabelText("Zoom in mind map");
     expect(zoomInButton).toHaveTextContent("+");
   });
 
@@ -82,7 +95,7 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
   });
 
   it("calls rescale with zoom factor when zoom in is clicked", async () => {
@@ -91,9 +104,9 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
 
-    const zoomInButton = screen.getByLabelText("Zoom in");
+    const zoomInButton = screen.getByLabelText("Zoom in mind map");
     await user.click(zoomInButton);
 
     expect(mockRescale).toHaveBeenCalledWith(1.5);
@@ -105,9 +118,9 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
 
-    const zoomOutButton = screen.getByLabelText("Zoom out");
+    const zoomOutButton = screen.getByLabelText("Zoom out mind map");
     await user.click(zoomOutButton);
 
     expect(mockRescale).toHaveBeenCalledWith(1 / 1.5);
@@ -119,9 +132,9 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
 
-    const fitButton = screen.getByLabelText("Fit to container");
+    const fitButton = screen.getByLabelText("Fit mind map to container");
     await user.click(fitButton);
 
     expect(mockFit).toHaveBeenCalled();
@@ -133,9 +146,9 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
 
-    const zoomInButton = screen.getByLabelText("Zoom in");
+    const zoomInButton = screen.getByLabelText("Zoom in mind map");
     await user.click(zoomInButton);
     await user.click(zoomInButton);
     await user.click(zoomInButton);
@@ -149,14 +162,14 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalledTimes(1);
-    });
+    }, { timeout: 3000 });
 
     const newMarkdown = "# New Root\n## New Child";
     rerender(<MarkmapView markdown={newMarkdown} />);
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalledTimes(2);
-    });
+    }, { timeout: 3000 });
   });
 
   it("does not re-create markmap when markdown stays the same", async () => {
@@ -164,7 +177,7 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalledTimes(1);
-    });
+    }, { timeout: 3000 });
 
     rerender(<MarkmapView markdown={sampleMarkdown} />);
 
@@ -192,9 +205,9 @@ describe("MarkmapView Component", () => {
 
     const buttons = screen.getAllByRole("button");
     expect(buttons).toHaveLength(3);
-    expect(buttons[0]).toHaveAttribute("aria-label", "Zoom out");
-    expect(buttons[1]).toHaveAttribute("aria-label", "Fit to container");
-    expect(buttons[2]).toHaveAttribute("aria-label", "Zoom in");
+    expect(buttons[0]).toHaveAttribute("aria-label", "Zoom out mind map");
+    expect(buttons[1]).toHaveAttribute("aria-label", "Fit mind map to container");
+    expect(buttons[2]).toHaveAttribute("aria-label", "Zoom in mind map");
   });
 
   it("handles empty markdown", async () => {
@@ -202,10 +215,10 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
 
     // Should still render controls
-    expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
+    expect(screen.getByLabelText("Zoom in mind map")).toBeInTheDocument();
   });
 
   it("cleans up markmap reference on unmount", async () => {
@@ -213,7 +226,7 @@ describe("MarkmapView Component", () => {
 
     await waitFor(() => {
       expect(mockCreate).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
 
     // Unmount should not throw
     expect(() => unmount()).not.toThrow();

--- a/__tests__/components/MediaLightbox.test.tsx
+++ b/__tests__/components/MediaLightbox.test.tsx
@@ -1,0 +1,460 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MediaLightbox } from "../../components/MediaLightbox";
+
+// Mock the MarkmapView component
+jest.mock("../../components/MarkmapView", () => ({
+  MarkmapView: ({ markdown, fullscreen }: any) => (
+    <div data-testid="markmap-view" data-markdown={markdown} data-fullscreen={fullscreen}>
+      Mocked MarkmapView
+    </div>
+  ),
+}));
+
+describe("MediaLightbox Component", () => {
+  const mockOnClose = jest.fn();
+  const sampleImageSrc = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+  const sampleMarkdown = "# Test Mindmap\n## Child Node";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Image Lightbox", () => {
+    it("renders image lightbox when open", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const image = screen.getByAltText("Visual response");
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute("src", sampleImageSrc);
+    });
+
+    it("renders close button for image lightbox", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const closeButton = screen.getByLabelText("Close lightbox");
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it("calls onClose when close button is clicked", async () => {
+      const user = userEvent.setup();
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const closeButton = screen.getByLabelText("Close lightbox");
+      await user.click(closeButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders zoom controls for image lightbox", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      expect(screen.getByLabelText("Zoom out")).toBeInTheDocument();
+      expect(screen.getByLabelText("Reset zoom")).toBeInTheDocument();
+      expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
+    });
+
+    it("displays 100% as initial zoom level", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const resetButton = screen.getByLabelText("Reset zoom");
+      expect(resetButton).toHaveTextContent("100%");
+    });
+
+    it("increases zoom level when zoom in is clicked", async () => {
+      const user = userEvent.setup();
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const zoomInButton = screen.getByLabelText("Zoom in");
+      await user.click(zoomInButton);
+
+      const resetButton = screen.getByLabelText("Reset zoom");
+      expect(resetButton).toHaveTextContent("150%");
+    });
+
+    it("decreases zoom level when zoom out is clicked", async () => {
+      const user = userEvent.setup();
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      // First zoom in
+      const zoomInButton = screen.getByLabelText("Zoom in");
+      await user.click(zoomInButton);
+
+      // Then zoom out
+      const zoomOutButton = screen.getByLabelText("Zoom out");
+      await user.click(zoomOutButton);
+
+      const resetButton = screen.getByLabelText("Reset zoom");
+      expect(resetButton).toHaveTextContent("100%");
+    });
+
+    it("resets zoom to 100% when reset button is clicked", async () => {
+      const user = userEvent.setup();
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      // Zoom in twice
+      const zoomInButton = screen.getByLabelText("Zoom in");
+      await user.click(zoomInButton);
+      await user.click(zoomInButton);
+
+      // Reset
+      const resetButton = screen.getByLabelText("Reset zoom");
+      await user.click(resetButton);
+
+      expect(resetButton).toHaveTextContent("100%");
+    });
+
+    it("disables zoom out button at minimum zoom", async () => {
+      const user = userEvent.setup();
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const zoomOutButton = screen.getByLabelText("Zoom out");
+      // Initially at 100%, should not be disabled (min is 50%)
+      expect(zoomOutButton).not.toBeDisabled();
+
+      // Zoom out to minimum (50%)
+      await user.click(zoomOutButton);
+
+      // Now should be disabled
+      expect(zoomOutButton).toBeDisabled();
+    });
+
+    it("disables zoom in button at maximum zoom", async () => {
+      const user = userEvent.setup();
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const zoomInButton = screen.getByLabelText("Zoom in");
+
+      // Zoom in to max (from 1 to 4 with 0.5 steps = 6 clicks)
+      for (let i = 0; i < 6; i++) {
+        await user.click(zoomInButton);
+      }
+
+      expect(zoomInButton).toBeDisabled();
+    });
+  });
+
+  describe("Mindmap Lightbox", () => {
+    it("renders mindmap lightbox when open", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="mindmap"
+          mediaSrc={sampleMarkdown}
+          isMobile={false}
+        />
+      );
+
+      const markmapView = screen.getByTestId("markmap-view");
+      expect(markmapView).toBeInTheDocument();
+      expect(markmapView).toHaveAttribute("data-markdown", sampleMarkdown);
+      expect(markmapView).toHaveAttribute("data-fullscreen", "true");
+    });
+
+    it("renders close button for mindmap lightbox", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="mindmap"
+          mediaSrc={sampleMarkdown}
+          isMobile={false}
+        />
+      );
+
+      const closeButton = screen.getByLabelText("Close lightbox");
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it("does not render image zoom controls for mindmap", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="mindmap"
+          mediaSrc={sampleMarkdown}
+          isMobile={false}
+        />
+      );
+
+      expect(screen.queryByLabelText("Zoom out")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Reset zoom")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Zoom in")).not.toBeInTheDocument();
+    });
+
+    it("does not render image element for mindmap", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="mindmap"
+          mediaSrc={sampleMarkdown}
+          isMobile={false}
+        />
+      );
+
+      expect(screen.queryByAltText("Visual response")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Desktop vs Mobile", () => {
+    it("renders with desktop dimensions for desktop image", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      // Verify desktop rendering by checking content is present
+      expect(screen.getByAltText("Visual response")).toBeInTheDocument();
+      expect(screen.getByLabelText("Close lightbox")).toBeInTheDocument();
+    });
+
+    it("renders with desktop dimensions for desktop mindmap", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="mindmap"
+          mediaSrc={sampleMarkdown}
+          isMobile={false}
+        />
+      );
+
+      // Verify desktop rendering by checking content is present
+      expect(screen.getByTestId("markmap-view")).toBeInTheDocument();
+      expect(screen.getByLabelText("Close lightbox")).toBeInTheDocument();
+    });
+
+    it("renders fullscreen for mobile", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={true}
+        />
+      );
+
+      // Verify mobile rendering by checking content is present
+      expect(screen.getByAltText("Visual response")).toBeInTheDocument();
+      expect(screen.getByLabelText("Close lightbox")).toBeInTheDocument();
+    });
+  });
+
+  describe("Open/Close Behavior", () => {
+    it("does not render when closed", () => {
+      render(
+        <MediaLightbox
+          open={false}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      expect(screen.queryByAltText("Visual response")).not.toBeInTheDocument();
+    });
+
+    it("resets zoom when reopening", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      // Zoom in
+      const zoomInButton = screen.getByLabelText("Zoom in");
+      await user.click(zoomInButton);
+
+      let resetButton = screen.getByLabelText("Reset zoom");
+      expect(resetButton).toHaveTextContent("150%");
+
+      // Close
+      rerender(
+        <MediaLightbox
+          open={false}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      // Reopen
+      rerender(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      resetButton = screen.getByLabelText("Reset zoom");
+      expect(resetButton).toHaveTextContent("100%");
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has proper ARIA labels", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("aria-labelledby", "media-lightbox-title");
+      expect(dialog).toHaveAttribute("aria-describedby", "media-lightbox-description");
+    });
+
+    it("close button has accessible label", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      const closeButton = screen.getByLabelText("Close lightbox");
+      expect(closeButton).toBeInTheDocument();
+    });
+
+    it("zoom controls have accessible labels for images", () => {
+      render(
+        <MediaLightbox
+          open={true}
+          onClose={mockOnClose}
+          mediaType="image"
+          mediaSrc={sampleImageSrc}
+          mimeType="image/png"
+          isMobile={false}
+        />
+      );
+
+      expect(screen.getByLabelText("Zoom out")).toBeInTheDocument();
+      expect(screen.getByLabelText("Reset zoom")).toBeInTheDocument();
+      expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/AssistantChatPanel.tsx
+++ b/components/AssistantChatPanel.tsx
@@ -1,4 +1,5 @@
-import React, { FC, useEffect, useMemo, useState } from "react";
+import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
+import { useTheme, useMediaQuery } from "@mui/material";
 import {
   AssistantMessage,
   SubmittedMessage,
@@ -20,6 +21,7 @@ import { useAutoScroll } from "../hooks/useAutoScroll";
 import { normalizeAssistantPseudonym } from "../utils/Helpers";
 import { BotIcon } from "./BotIcon";
 import { PreferencesBanner, PreferenceOption } from "./PreferencesBanner";
+import { MediaLightbox } from "./MediaLightbox";
 
 /**
  * Parsed message body structure
@@ -103,11 +105,49 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
 }) => {
   const { messagesEndRef, messagesContainerRef } = useAutoScroll(messages);
   const [preferencesVisible, setPreferencesVisible] = useState(showPreferences);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  // Lightbox state for images and mindmaps
+  const [lightboxState, setLightboxState] = useState<{
+    isOpen: boolean;
+    mediaType: "image" | "mindmap";
+    mediaSrc: string;
+    mimeType?: string;
+  }>({
+    isOpen: false,
+    mediaType: "image",
+    mediaSrc: "",
+    mimeType: undefined,
+  });
 
   // Sync local state with prop changes
   useEffect(() => {
     setPreferencesVisible(showPreferences);
   }, [showPreferences]);
+
+  // Lightbox handlers
+  const handleImageClick = useCallback((src: string, mimeType: string) => {
+    setLightboxState({
+      isOpen: true,
+      mediaType: "image",
+      mediaSrc: src,
+      mimeType,
+    });
+  }, []);
+
+  const handleMarkmapClick = useCallback((markdown: string) => {
+    setLightboxState({
+      isOpen: true,
+      mediaType: "mindmap",
+      mediaSrc: markdown,
+      mimeType: undefined,
+    });
+  }, []);
+
+  const handleLightboxClose = useCallback(() => {
+    setLightboxState((prev) => ({ ...prev, isOpen: false }));
+  }, []);
 
   // Create enhancers for assistant mode (slash commands only)
   const enhancers = useMemo(() => {
@@ -396,6 +436,8 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
                                 }}
                                 media={parsed.media}
                                 onPromptSelect={onPromptSelect}
+                                onImageClick={handleImageClick}
+                                onMarkmapClick={handleMarkmapClick}
                               />
                             </div>
                           ) : (
@@ -415,6 +457,8 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
                                 }}
                                 media={parsed.media}
                                 onPromptSelect={onPromptSelect}
+                                onImageClick={handleImageClick}
+                                onMarkmapClick={handleMarkmapClick}
                               />
                             </div>
                           )}
@@ -483,6 +527,16 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
           onInputChange={onInputChange}
         />
       </div>
+
+      {/* Media Lightbox */}
+      <MediaLightbox
+        open={lightboxState.isOpen}
+        onClose={handleLightboxClose}
+        mediaType={lightboxState.mediaType}
+        mediaSrc={lightboxState.mediaSrc}
+        mimeType={lightboxState.mimeType}
+        isMobile={isMobile}
+      />
     </div>
   );
 };

--- a/components/MarkmapView.tsx
+++ b/components/MarkmapView.tsx
@@ -2,11 +2,13 @@ import { useCallback, useEffect, useRef, memo } from "react";
 
 interface MarkmapViewProps {
   markdown: string;
+  onClick?: () => void;
+  fullscreen?: boolean;
 }
 
 const ZOOM_STEP = 1.5;
 
-const MarkmapViewComponent = ({ markdown }: MarkmapViewProps) => {
+const MarkmapViewComponent = ({ markdown, onClick, fullscreen = false }: MarkmapViewProps) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const mmRef = useRef<any>(null);
 
@@ -53,16 +55,25 @@ const MarkmapViewComponent = ({ markdown }: MarkmapViewProps) => {
       rafId = requestAnimationFrame(() => {
         if (!mounted || !svg.isConnected) return;
 
-        // Create with merged options
-        const mm = Markmap.create(svg, markmapOptions, root);
-        mmRef.current = mm;
+        // Check if SVG has valid dimensions before creating Markmap
+        const rect = svg.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) return;
 
-        // Call fit manually after creation
-        requestAnimationFrame(() => {
-          if (mounted && mm) {
-            mm.fit();
-          }
-        });
+        try {
+          // Create with merged options
+          const mm = Markmap.create(svg, markmapOptions, root);
+          mmRef.current = mm;
+
+          // Call fit manually after creation
+          requestAnimationFrame(() => {
+            if (mounted && mm) {
+              mm.fit();
+            }
+          });
+        } catch (error) {
+          // Silently handle SVG dimension errors during page rerenders
+          console.debug("Markmap creation skipped due to invalid SVG state");
+        }
       });
     };
 
@@ -93,36 +104,82 @@ const MarkmapViewComponent = ({ markdown }: MarkmapViewProps) => {
   }, []);
 
   return (
-    <div className="w-full">
+    <div
+      className="w-full"
+      onClick={onClick}
+      style={{ cursor: onClick ? "pointer" : "default" }}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
+    >
+      {/* Hidden text for screen readers */}
+      <div
+        style={{
+          position: "absolute",
+          width: "1px",
+          height: "1px",
+          padding: "0",
+          margin: "-1px",
+          overflow: "hidden",
+          clip: "rect(0, 0, 0, 0)",
+          whiteSpace: "nowrap",
+          border: "0",
+        }}
+      >
+        {markdown}
+      </div>
+
       <div className="flex justify-end gap-1 mb-1">
         <button
-          onClick={handleZoomOut}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleZoomOut();
+          }}
           className="px-2 py-0.5 text-sm rounded bg-gray-200 hover:bg-gray-300 text-gray-700"
-          aria-label="Zoom out"
+          aria-label="Zoom out mind map"
         >
           −
         </button>
         <button
-          onClick={handleFit}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleFit();
+          }}
           className="px-2 py-0.5 text-sm rounded bg-gray-200 hover:bg-gray-300 text-gray-700"
-          aria-label="Fit to container"
+          aria-label="Fit mind map to container"
         >
           fit
         </button>
         <button
-          onClick={handleZoomIn}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleZoomIn();
+          }}
           className="px-2 py-0.5 text-sm rounded bg-gray-200 hover:bg-gray-300 text-gray-700"
-          aria-label="Zoom in"
+          aria-label="Zoom in mind map"
         >
           +
         </button>
       </div>
-      <div className="bg-white rounded p-2">
+      <div
+        className="bg-white rounded p-2"
+        role="img"
+        aria-label="Interactive mind map visualization. Use zoom controls to navigate."
+      >
         <svg
           ref={svgRef}
           style={{
             width: "100%",
-            height: "400px",
+            height: fullscreen ? "calc(90vh - 120px)" : "400px",
           }}
         />
       </div>

--- a/components/MediaLightbox.tsx
+++ b/components/MediaLightbox.tsx
@@ -1,0 +1,294 @@
+import { FC, useState, useCallback, useEffect, useRef } from "react";
+import { Dialog, IconButton, Box } from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import { MarkmapView } from "./MarkmapView";
+
+// Store the original viewport content
+let originalViewportContent = "";
+
+interface MediaLightboxProps {
+  open: boolean;
+  onClose: () => void;
+  mediaType: "image" | "mindmap";
+  mediaSrc: string;
+  mimeType?: string;
+  isMobile: boolean;
+}
+
+const ZOOM_STEP = 0.5;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 4;
+
+export const MediaLightbox: FC<MediaLightboxProps> = ({
+  open,
+  onClose,
+  mediaType,
+  mediaSrc,
+  mimeType,
+  isMobile,
+}) => {
+  const [zoomLevel, setZoomLevel] = useState(1);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  // Reset zoom and position when opening/closing
+  // Also prevent viewport zoom on mobile
+  useEffect(() => {
+    if (open) {
+      setZoomLevel(1);
+      setPosition({ x: 0, y: 0 });
+
+      // On mobile, disable viewport zoom to prevent the page from staying zoomed
+      if (isMobile) {
+        const viewportMeta = document.querySelector('meta[name="viewport"]');
+        if (viewportMeta) {
+          originalViewportContent = viewportMeta.getAttribute("content") || "";
+          viewportMeta.setAttribute(
+            "content",
+            "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no",
+          );
+        }
+      }
+    } else {
+      // Restore original viewport settings when closing
+      if (isMobile && originalViewportContent) {
+        const viewportMeta = document.querySelector('meta[name="viewport"]');
+        if (viewportMeta) {
+          viewportMeta.setAttribute("content", originalViewportContent);
+        }
+      }
+    }
+  }, [open, isMobile]);
+
+  const handleZoomIn = useCallback(() => {
+    setZoomLevel((prev) => Math.min(prev + ZOOM_STEP, MAX_ZOOM));
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    setZoomLevel((prev) => Math.max(prev - ZOOM_STEP, MIN_ZOOM));
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setZoomLevel(1);
+    setPosition({ x: 0, y: 0 });
+  }, []);
+
+  // Mouse wheel zoom
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (mediaType !== "image") return;
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP;
+      setZoomLevel((prev) =>
+        Math.max(MIN_ZOOM, Math.min(prev + delta, MAX_ZOOM)),
+      );
+    },
+    [mediaType],
+  );
+
+  // Pan functionality
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (mediaType !== "image" || zoomLevel <= 1) return;
+      setIsDragging(true);
+      setDragStart({ x: e.clientX - position.x, y: e.clientY - position.y });
+    },
+    [mediaType, zoomLevel, position],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging) return;
+      setPosition({
+        x: e.clientX - dragStart.x,
+        y: e.clientY - dragStart.y,
+      });
+    },
+    [isDragging, dragStart],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Keyboard controls
+  useEffect(() => {
+    if (!open || mediaType !== "image") return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      } else if (e.key === "+" || e.key === "=") {
+        handleZoomIn();
+      } else if (e.key === "-" || e.key === "_") {
+        handleZoomOut();
+      } else if (e.key === "0") {
+        handleReset();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, mediaType, onClose, handleZoomIn, handleZoomOut, handleReset]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen={isMobile}
+      maxWidth={false}
+      aria-labelledby="media-lightbox-title"
+      aria-describedby="media-lightbox-description"
+      slotProps={{
+        paper: {
+          sx: {
+            backgroundColor: "rgba(0, 0, 0, 0.95)",
+            ...(isMobile
+              ? {}
+              : mediaType === "mindmap"
+                ? {
+                    width: "95vw",
+                    height: "90vh",
+                    margin: "auto",
+                  }
+                : {
+                    maxWidth: "90vw",
+                    maxHeight: "90vh",
+                    margin: "auto",
+                  }),
+          },
+        },
+      }}
+    >
+      {/* Close button */}
+      <IconButton
+        onClick={onClose}
+        aria-label="Close lightbox"
+        sx={{
+          position: "absolute",
+          bottom: 24,
+          right: 16,
+          color: "white",
+          zIndex: 1,
+          backgroundColor: "rgba(0, 0, 0, 0.5)",
+          "&:hover": {
+            backgroundColor: "rgba(0, 0, 0, 0.7)",
+          },
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
+
+      {/* Content */}
+      <Box
+        sx={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          overflow: "hidden",
+          position: "relative",
+        }}
+      >
+        {mediaType === "image" ? (
+          <>
+            {/* Image container */}
+            <Box
+              sx={{
+                flex: 1,
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                overflow: "hidden",
+                cursor:
+                  zoomLevel > 1
+                    ? isDragging
+                      ? "grabbing"
+                      : "grab"
+                    : "default",
+              }}
+              onWheel={handleWheel}
+              onMouseDown={handleMouseDown}
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+              onMouseLeave={handleMouseUp}
+            >
+              <img
+                ref={imageRef}
+                src={mediaSrc}
+                alt="Visual response"
+                style={{
+                  maxWidth: zoomLevel === 1 ? "100%" : "none",
+                  maxHeight: zoomLevel === 1 ? "100%" : "none",
+                  transform: `scale(${zoomLevel}) translate(${position.x / zoomLevel}px, ${
+                    position.y / zoomLevel
+                  }px)`,
+                  transition: isDragging ? "none" : "transform 0.2s ease-out",
+                  touchAction: "pan-x pan-y pinch-zoom",
+                  userSelect: "none",
+                }}
+              />
+            </Box>
+
+            {/* Zoom controls */}
+            <Box
+              sx={{
+                position: "absolute",
+                bottom: 24,
+                left: "50%",
+                transform: "translateX(-50%)",
+                display: "flex",
+                gap: 1,
+                backgroundColor: "rgba(0, 0, 0, 0.7)",
+                padding: "8px 12px",
+                borderRadius: "24px",
+              }}
+            >
+              <button
+                onClick={handleZoomOut}
+                disabled={zoomLevel <= MIN_ZOOM}
+                className="px-3 py-1 text-sm rounded bg-gray-700 hover:bg-gray-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="Zoom out"
+              >
+                −
+              </button>
+              <button
+                onClick={handleReset}
+                className="px-3 py-1 text-sm rounded bg-gray-700 hover:bg-gray-600 text-white"
+                aria-label="Reset zoom"
+              >
+                {Math.round(zoomLevel * 100)}%
+              </button>
+              <button
+                onClick={handleZoomIn}
+                disabled={zoomLevel >= MAX_ZOOM}
+                className="px-3 py-1 text-sm rounded bg-gray-700 hover:bg-gray-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="Zoom in"
+              >
+                +
+              </button>
+            </Box>
+          </>
+        ) : (
+          // Mindmap
+          <Box
+            sx={{
+              width: "100%",
+              height: "100%",
+              padding: isMobile ? 0.5 : 1,
+              paddingTop: isMobile ? 0.5 : 1,
+              overflow: "auto",
+            }}
+          >
+            <MarkmapView markdown={mediaSrc} fullscreen />
+          </Box>
+        )}
+      </Box>
+    </Dialog>
+  );
+};

--- a/components/messages/AssistantMessage.tsx
+++ b/components/messages/AssistantMessage.tsx
@@ -7,12 +7,16 @@ import { MessageProps, MediaItem } from "../../types.internal";
 export interface AssistantMessageProps extends MessageProps {
   onPromptSelect?: (value: string, parentMessageId?: string) => void;
   media?: MediaItem[];
+  onImageClick?: (src: string, mimeType: string) => void;
+  onMarkmapClick?: (markdown: string) => void;
 }
 
 export const AssistantMessage: FC<AssistantMessageProps> = ({
   message,
   onPromptSelect,
   media,
+  onImageClick,
+  onMarkmapClick,
 }) => {
   const [selectedPrompt, setSelectedPrompt] = useState<string | null>(null);
 
@@ -35,7 +39,7 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
 
   return (
     <BaseMessage className={className}>
-      <MessageContent text={message.body as string} />
+      <MessageContent text={message.body as string} onMarkmapClick={onMarkmapClick} />
 
       {/* Render media items */}
       {media && media.length > 0 && (
@@ -47,16 +51,29 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
         >
           {media.map((item, index) => {
             if (item.type === "image") {
+              const imgSrc = `data:${item.mimeType};base64,${item.data}`;
               return (
                 <img
                   key={`media-${index}`}
-                  src={`data:${item.mimeType};base64,${item.data}`}
+                  src={imgSrc}
                   alt="Visual response"
+                  role="button"
+                  tabIndex={0}
+                  className="hover:scale-105"
                   style={{
                     maxWidth: "100%",
                     height: "auto",
                     borderRadius: "8px",
                     border: "1px solid rgba(0, 0, 0, 0.1)",
+                    cursor: "pointer",
+                    transition: "transform 0.2s ease-in-out",
+                  }}
+                  onClick={() => onImageClick?.(imgSrc, item.mimeType)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onImageClick?.(imgSrc, item.mimeType);
+                    }
                   }}
                 />
               );

--- a/components/messages/BaseMessage.tsx
+++ b/components/messages/BaseMessage.tsx
@@ -32,6 +32,7 @@ export const BaseMessage: FC<BaseMessageProps> = ({
 interface MessageContentProps {
   text: string;
   isFeedback?: boolean;
+  onMarkmapClick?: (markdown: string) => void;
 }
 
 /**
@@ -40,6 +41,7 @@ interface MessageContentProps {
 export const MessageContent: FC<MessageContentProps> = ({
   text,
   isFeedback = false,
+  onMarkmapClick,
 }) => {
   const isFeedbackMessage = text.startsWith("/feedback");
   const displayText = isFeedbackMessage ? "User feedback received." : text;
@@ -60,7 +62,12 @@ export const MessageContent: FC<MessageContentProps> = ({
         const hasMarkmapFrontMatter =
           /^---\s*\n[\s\S]*?\bmarkmap\s*:[\s\S]*?\n---/.test(content);
         if (lang === "markmap" || hasMarkmapFrontMatter) {
-          return <MarkmapView markdown={content} />;
+          return (
+            <MarkmapView
+              markdown={content}
+              onClick={() => onMarkmapClick?.(content)}
+            />
+          );
         }
         return (
           <code className={className} {...props}>
@@ -69,7 +76,7 @@ export const MessageContent: FC<MessageContentProps> = ({
         );
       },
     }),
-    []
+    [onMarkmapClick]
   );
 
   if (isFeedbackMessage || isFeedback) {


### PR DESCRIPTION
## What is in this PR?

Adds a clickable lightbox for visual and mindmap responses to allow the user to more easily view in horizontal mobile orientation, zoom, etc. Works on both laptop and mobile

## Changes in the codebase

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Using the preview build, create a Berkie convo and set the visual preference to true
- [ ] Send a /mindmap and click on the generated image. Verify lightbox is displayed with mindmap. Ensure can pan, zoom, fit, etc and close dialog
- [ ] Ensure can still pan, zoom, fit the mindmap in the assistant page as well
- [ ] Do something to generate a visual response (ask for summarization, process, timeline, etc)
- [ ] Click on the generated image. Verify lightbox is displayed with image
- [ ] Close dialog
- [ ] Do above on mobile and desktop. Rotate images to horizontal orientation and verify can actually see them.


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
