### PR TITLE
feat: add support for choosing features when creating an event

### DIFF
--- a/__tests__/components/Event.Test.tsx
+++ b/__tests__/components/Event.Test.tsx
@@ -19,9 +19,7 @@ describe("Event Component", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Conversation Configuration")
-      ).toBeInTheDocument();
+      expect(screen.getByText("Conversation Setup")).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -130,6 +130,30 @@ const mockConfig = {
           ],
         },
       ],
+      features: [
+        {
+          name: "liveTranscript",
+          label: "Live Transcript",
+          description: "Display a live transcript during the event",
+          default: false,
+          properties: [
+            {
+              name: "transcriptDelay",
+              type: "number",
+              label: "Transcript Delay (seconds)",
+              default: 5,
+              required: false,
+            },
+          ],
+        },
+        {
+          name: "autoSummary",
+          label: "Auto Summary",
+          description: "Generate a summary at the end of the event",
+          default: false,
+          properties: [],
+        },
+      ],
     },
     {
       name: "eventAssistant",
@@ -202,8 +226,8 @@ describe("EventCreationForm Component", () => {
 
     // Check that all step labels are present in the stepper
     expect(screen.getAllByText("Event Details").length).toBeGreaterThan(0);
-    expect(screen.getByText("Conversation Configuration")).toBeInTheDocument();
-    expect(screen.getByText("Agent Configuration")).toBeInTheDocument();
+    expect(screen.getByText("Conversation Setup")).toBeInTheDocument();
+    expect(screen.getByText("Configuration")).toBeInTheDocument();
     expect(screen.getByText("Moderators & Speakers")).toBeInTheDocument();
 
     // Should show Step 1 content
@@ -1118,6 +1142,194 @@ describe("EventCreationForm Component", () => {
       });
       // First model (gpt-4o-mini) should be selected by default
       expect(gptRadio).toBeChecked();
+    });
+  });
+
+  // Helper to navigate to Step 3 with Back Channel selected
+  const navigateToStep3WithBackChannel = async (user: ReturnType<typeof userEvent.setup>) => {
+    await fillEventDetails("Test Event", "https://huitstage.zoom.us/j/1234567890");
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => screen.getByText("Nextspace"));
+    await user.click(screen.getByRole("checkbox", { name: /zoom/i }));
+    await user.click(screen.getByRole("radio", { name: /back channel/i }));
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => screen.getByLabelText(/Bot Name/i));
+  };
+
+  describe("Features", () => {
+    it("displays the Features section on Step 3 when the conversation type has features", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep3WithBackChannel(user);
+
+      expect(screen.getByText("Features")).toBeInTheDocument();
+      expect(screen.getByText("Live Transcript")).toBeInTheDocument();
+      expect(
+        screen.getByText("Display a live transcript during the event"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Auto Summary")).toBeInTheDocument();
+    });
+
+    it("feature checkboxes are unchecked by default when feature.default is false", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep3WithBackChannel(user);
+
+      const liveTranscriptCheckbox = screen.getByRole("checkbox", {
+        name: /live transcript/i,
+      });
+      expect(liveTranscriptCheckbox).not.toBeChecked();
+
+      const autoSummaryCheckbox = screen.getByRole("checkbox", {
+        name: /auto summary/i,
+      });
+      expect(autoSummaryCheckbox).not.toBeChecked();
+    });
+
+    it("toggling a feature checkbox shows its sub-properties", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep3WithBackChannel(user);
+
+      // Sub-property should not be visible before enabling the feature
+      expect(
+        screen.queryByLabelText(/Transcript Delay/i),
+      ).not.toBeInTheDocument();
+
+      const liveTranscriptCheckbox = screen.getByRole("checkbox", {
+        name: /live transcript/i,
+      });
+      await user.click(liveTranscriptCheckbox);
+
+      expect(liveTranscriptCheckbox).toBeChecked();
+      expect(screen.getByLabelText(/Transcript Delay/i)).toBeInTheDocument();
+    });
+
+    it("unchecking a feature hides its sub-properties", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep3WithBackChannel(user);
+
+      const liveTranscriptCheckbox = screen.getByRole("checkbox", {
+        name: /live transcript/i,
+      });
+      await user.click(liveTranscriptCheckbox);
+      expect(screen.getByLabelText(/Transcript Delay/i)).toBeInTheDocument();
+
+      await user.click(liveTranscriptCheckbox);
+      expect(liveTranscriptCheckbox).not.toBeChecked();
+      expect(
+        screen.queryByLabelText(/Transcript Delay/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not include features in submission payload when none are enabled", async () => {
+      const user = userEvent.setup();
+      (Request as jest.Mock).mockResolvedValue({
+        id: "conv-no-features",
+        name: "Test Event",
+        channels: [],
+        agents: [],
+        adapters: [],
+        conversationType: "backChannel",
+      });
+
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep3WithBackChannel(user);
+      await user.click(screen.getByRole("button", { name: /next/i }));
+      await waitFor(() => screen.getByText("About the Speakers"));
+      await user.click(
+        screen.getByRole("button", { name: /create conversation/i }),
+      );
+
+      await waitFor(() => {
+        const call = (Request as jest.Mock).mock.calls[0];
+        expect(call[1]).not.toHaveProperty("features");
+      });
+    });
+
+    it("includes enabled features with their properties in the submission payload", async () => {
+      const user = userEvent.setup();
+      (Request as jest.Mock).mockResolvedValue({
+        id: "conv-with-features",
+        name: "Test Event",
+        channels: [],
+        agents: [],
+        adapters: [],
+        conversationType: "backChannel",
+      });
+
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep3WithBackChannel(user);
+
+      // Enable the liveTranscript feature
+      await user.click(
+        screen.getByRole("checkbox", { name: /live transcript/i }),
+      );
+
+      // Also enable autoSummary
+      await user.click(
+        screen.getByRole("checkbox", { name: /auto summary/i }),
+      );
+
+      await user.click(screen.getByRole("button", { name: /next/i }));
+      await waitFor(() => screen.getByText("About the Speakers"));
+      await user.click(
+        screen.getByRole("button", { name: /create conversation/i }),
+      );
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          "conversations/from-type",
+          expect.objectContaining({
+            features: expect.arrayContaining([
+              { name: "liveTranscript", config: { transcriptDelay: 5 } },
+              { name: "autoSummary", config: {} },
+            ]),
+          }),
+        );
+      });
+    });
+
+    it("does not show Features section when conversationType has no features", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await fillEventDetails(
+        "Test Event",
+        "https://huitstage.zoom.us/j/1234567890",
+      );
+      await user.click(screen.getByRole("button", { name: /next/i }));
+      await waitFor(() => screen.getByText("Nextspace"));
+      await user.click(screen.getByRole("checkbox", { name: /zoom/i }));
+      // Event Assistant has no features in the mock config
+      await user.click(
+        screen.getByRole("radio", { name: /event assistant/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /next/i }));
+      await waitFor(() => screen.getByLabelText(/Bot Name/i));
+
+      expect(screen.queryByText("Features")).not.toBeInTheDocument();
     });
   });
 });

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   Checkbox,
+  Divider,
   FormControl,
   FormControlLabel,
   FormGroup,
@@ -35,8 +36,8 @@ import { useField } from "@mui/x-date-pickers/internals";
 
 const steps = [
   "Event Details",
-  "Conversation Configuration",
-  "Agent Configuration",
+  "Conversation Setup",
+  "Configuration",
   "Moderators & Speakers",
 ];
 
@@ -164,6 +165,18 @@ export const EventCreationForm: React.FC = ({}) => {
             }
           }
         });
+        // Initialize feature toggles and their sub-property defaults.
+        // Sub-properties are keyed as `featureName.propName` to avoid
+        // collisions when multiple features share the same property name.
+        type.features?.forEach((feature) => {
+          initialValues[feature.name] = feature.default;
+          feature.properties?.forEach((prop) => {
+            if (prop.default !== undefined) {
+              initialValues[`${feature.name}.${prop.name}`] = prop.default;
+            }
+          });
+        });
+
         setDynamicPropertyValues(initialValues);
       }
     }
@@ -297,18 +310,22 @@ export const EventCreationForm: React.FC = ({}) => {
     setSpeakers(updated);
   };
 
-  // Helper function to render dynamic property fields
+  // Helper function to render dynamic property fields.
+  // Pass `namespace` (feature name) to scope sub-property keys and prevent
+  // collisions when multiple features share the same property name.
   const renderDynamicPropertyField = (
-    prop: components["schemas"]["ConversationTypeProperty"],
+    prop: components["schemas"]["ConfigProperty"],
+    namespace?: string,
   ) => {
-    const value = dynamicPropertyValues[prop.name];
+    const stateKey = namespace ? `${namespace}.${prop.name}` : prop.name;
+    const value = dynamicPropertyValues[stateKey];
 
     switch (prop.type) {
       case "string":
         return (
           <TextField
-            key={prop.name}
-            name={prop.name}
+            key={stateKey}
+            name={stateKey}
             label={prop.label}
             value={value || prop.default || ""}
             helperText={prop.description}
@@ -319,7 +336,7 @@ export const EventCreationForm: React.FC = ({}) => {
             onChange={(e) => {
               setDynamicPropertyValues((prev) => ({
                 ...prev,
-                [prop.name]: e.target.value,
+                [stateKey]: e.target.value,
               }));
             }}
           />
@@ -328,8 +345,8 @@ export const EventCreationForm: React.FC = ({}) => {
       case "number":
         return (
           <TextField
-            key={prop.name}
-            name={prop.name}
+            key={stateKey}
+            name={stateKey}
             label={prop.label}
             type="number"
             value={
@@ -346,16 +363,38 @@ export const EventCreationForm: React.FC = ({}) => {
               if (inputValue === "") {
                 setDynamicPropertyValues((prev) => ({
                   ...prev,
-                  [prop.name]: 0,
+                  [stateKey]: 0,
                 }));
               } else {
                 const numValue = parseInt(inputValue, 10);
                 setDynamicPropertyValues((prev) => ({
                   ...prev,
-                  [prop.name]: isNaN(numValue) ? 0 : numValue,
+                  [stateKey]: isNaN(numValue) ? 0 : numValue,
                 }));
               }
             }}
+          />
+        );
+
+      case "boolean":
+        return (
+          <FormControlLabel
+            key={stateKey}
+            control={
+              <Checkbox
+                checked={
+                  value !== undefined ? Boolean(value) : Boolean(prop.default)
+                }
+                onChange={(e) => {
+                  setDynamicPropertyValues((prev) => ({
+                    ...prev,
+                    [stateKey]: e.target.checked,
+                  }));
+                }}
+              />
+            }
+            label={prop.label}
+            sx={{ mt: 1 }}
           />
         );
 
@@ -364,7 +403,7 @@ export const EventCreationForm: React.FC = ({}) => {
         if (prop.options && Array.isArray(prop.options)) {
           return (
             <FormControl
-              key={prop.name}
+              key={stateKey}
               component="fieldset"
               fullWidth
               margin="normal"
@@ -400,13 +439,13 @@ export const EventCreationForm: React.FC = ({}) => {
               )}
               <RadioGroup
                 value={JSON.stringify(value || {})}
-                name={prop.name}
+                name={stateKey}
                 onChange={(e) => {
                   try {
                     const parsedValue = JSON.parse(e.target.value);
                     setDynamicPropertyValues((prev) => ({
                       ...prev,
-                      [prop.name]: parsedValue,
+                      [stateKey]: parsedValue,
                     }));
                   } catch (err) {
                     console.error("Failed to parse radio value:", err);
@@ -475,7 +514,7 @@ export const EventCreationForm: React.FC = ({}) => {
           const itemKey = prop.itemKey || "name";
 
           return (
-            <Box key={prop.name} sx={{ mb: 3 }}>
+            <Box key={stateKey} sx={{ mb: 3 }}>
               <FormLabel
                 sx={{
                   fontSize: "0.875rem",
@@ -572,8 +611,8 @@ export const EventCreationForm: React.FC = ({}) => {
                                     onChange={(e) => {
                                       setDynamicPropertyValues((prev) => ({
                                         ...prev,
-                                        [prop.name]: {
-                                          ...prev[prop.name],
+                                        [stateKey]: {
+                                          ...prev[stateKey],
                                           [key]: {
                                             ...itemValue,
                                             [fieldKey]: e.target.checked,
@@ -619,8 +658,8 @@ export const EventCreationForm: React.FC = ({}) => {
                                   }
                                   setDynamicPropertyValues((prev) => ({
                                     ...prev,
-                                    [prop.name]: {
-                                      ...prev[prop.name],
+                                    [stateKey]: {
+                                      ...prev[stateKey],
                                       [key]: {
                                         ...itemValue,
                                         [fieldKey]: newValue,
@@ -647,8 +686,8 @@ export const EventCreationForm: React.FC = ({}) => {
                                 onChange={(e) => {
                                   setDynamicPropertyValues((prev) => ({
                                     ...prev,
-                                    [prop.name]: {
-                                      ...prev[prop.name],
+                                    [stateKey]: {
+                                      ...prev[stateKey],
                                       [key]: {
                                         ...itemValue,
                                         [fieldKey]: e.target.value,
@@ -745,11 +784,25 @@ export const EventCreationForm: React.FC = ({}) => {
       });
     }
 
-    console.log("Final properties object:", properties);
+    const features = (selectedType?.features ?? [])
+      .filter((feature) => Boolean(dynamicPropertyValues[feature.name]))
+      .map((feature) => {
+        const config: Record<string, any> = {};
+        feature.properties?.forEach((prop) => {
+          const value = dynamicPropertyValues[`${feature.name}.${prop.name}`];
+          if (value !== undefined && value !== null && value !== "") {
+            config[prop.name] = value;
+          } else if (prop.default !== undefined) {
+            config[prop.name] = prop.default;
+          }
+        });
+        return { name: feature.name, config };
+      });
 
     body = {
       ...body,
       properties,
+      ...(features.length > 0 && { features }),
     };
 
     Request("conversations/from-type", body)
@@ -930,11 +983,11 @@ export const EventCreationForm: React.FC = ({}) => {
             </Box>
           )}
 
-          {/* Step 2: Conversation Configuration */}
+          {/* Step 2: Conversation Setup */}
           {activeStep === 1 && (
             <Box>
               <Typography variant="h5" component="h2" gutterBottom>
-                Conversation Configuration
+                Conversation Setup
               </Typography>
 
               {/* Platform Selection */}
@@ -1062,20 +1115,96 @@ export const EventCreationForm: React.FC = ({}) => {
             </Box>
           )}
 
-          {/* Step 3: Agent Configuration */}
+          {/* Step 3: Configuration */}
           {activeStep === 2 && (
             <Box>
               <Typography variant="h5" component="h2" gutterBottom>
-                Agent Configuration
+                Configuration
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-                Configure your agent&apos;s behavior and settings
+                Customize your conversation settings
               </Typography>
 
               {conversationTypes
                 ?.find((type) => type.name === selectedConvType)
                 ?.properties?.filter((prop) => prop.name !== "zoomMeetingUrl")
                 .map((prop) => renderDynamicPropertyField(prop))}
+
+              {(() => {
+                const features = conversationTypes?.find(
+                  (type) => type.name === selectedConvType,
+                )?.features;
+                if (!features?.length) return null;
+                return (
+                  <Box sx={{ mt: 3 }}>
+                    <Divider sx={{ mb: 2 }} />
+                    <Typography
+                      variant="subtitle1"
+                      fontWeight={600}
+                      gutterBottom
+                    >
+                      Features
+                    </Typography>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mb: 2 }}
+                    >
+                      Enable additional capabilities for this conversation
+                    </Typography>
+                    {features.map((feature) => (
+                      <Box
+                        key={feature.name}
+                        sx={{
+                          mb: 1,
+                          p: 2,
+                          border: "1px solid",
+                          borderColor: dynamicPropertyValues[feature.name]
+                            ? "primary.main"
+                            : "divider",
+                          borderRadius: 1,
+                          transition: "border-color 0.2s",
+                        }}
+                      >
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              checked={Boolean(
+                                dynamicPropertyValues[feature.name],
+                              )}
+                              onChange={(e) => {
+                                setDynamicPropertyValues((prev) => ({
+                                  ...prev,
+                                  [feature.name]: e.target.checked,
+                                }));
+                              }}
+                            />
+                          }
+                          label={
+                            <Box>
+                              <Typography fontWeight={500}>
+                                {feature.label}
+                              </Typography>
+                              {feature.description && (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                >
+                                  {feature.description}
+                                </Typography>
+                              )}
+                            </Box>
+                          }
+                        />
+                        {dynamicPropertyValues[feature.name] &&
+                          feature.properties?.map((prop) =>
+                            renderDynamicPropertyField(prop, feature.name),
+                          )}
+                      </Box>
+                    ))}
+                  </Box>
+                );
+              })()}
             </Box>
           )}
 

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -92,13 +92,13 @@ export class Api {
     access: string,
     refresh: string,
     accessExpires?: string,
-    refreshExpires?: string
+    refreshExpires?: string,
   ) {
     TokenManagerDefault.setTokensFromStrings(
       access,
       refresh,
       accessExpires,
-      refreshExpires
+      refreshExpires,
     );
   }
 
@@ -293,6 +293,13 @@ async function getTypeForConversation(
       (type) => type.name === conversation.conversationType,
     );
     if (type) return type;
+    // backwards compatibility for removed conversation types like eventAssistantPlusProactive
+    return {
+      name: conversation.conversationType,
+      description: "",
+      platforms: [],
+      properties: [],
+    } as components["schemas"]["ConversationType"];
   }
   const agentNames = conversation.agents.map((agent) => agent.agentType);
   // Bit of a hack to support legacy conversations without a type. Takes advantage of the fact that


### PR DESCRIPTION
## What is in this PR?

- Adds conversation features to the Event Creation Form to allow event creators to enable/disable and configure features
- Backwards compatibility fix to support existing conversations with conversation type `eventAssistantPlusProactive` (assigns conversations a dummy type with that name)

## Changes in the codebase

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Create event of type `eventAssistantPlus` and disable both features
- [ ] Ensure conversation created OK and does not contain any proactive chat pushes
- [ ] Create event of type `eventAssistantPlus` and disable only one of the features. Change the contributionInterval (maybe down to one minute) on the one you leave enabled
- [ ] Ensure conversation created OK and some proactive pushes are in the convo at the expected interval

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
