### PR TITLE
fix: Set session secret into base-64 encoded buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Nextspace uses a hybrid authentication model that supports both anonymous partic
 - Guest pseudonyms are for **participation**, not authentication
 - Session cookies are encrypted and HTTP-only for security
 - Certain pages (home, login, signup, logout) skip automatic guest session creation to avoid unnecessary accounts
-- The `SESSION_SECRET` environment variable must be at least 32 characters for secure cookie encryption
+- The `SESSION_SECRET` environment variable must be a base64-encoded 32-byte key (44 characters) for secure cookie encryption
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Nextspace uses a hybrid authentication model that supports both anonymous partic
 ### Authentication Types
 
 **Guest (authType="guest")**
+
 - Automatically created when users visit most pages
 - Assigned a pseudonym (e.g., "Gentle Deer", "Brave Fox") for participation in conversations
 - No login required - sessions are created automatically in the background
@@ -16,12 +17,14 @@ Nextspace uses a hybrid authentication model that supports both anonymous partic
 - Session persists via encrypted cookie for 30 days
 
 **Admin (authType="admin")**
+
 - Requires explicit login with username and password via `/login`
 - Full access to administrative routes (`/admin/*`)
 - Can create and manage events, configure agents, view analytics
 - Non-admin users attempting to access `/admin` routes are redirected to signup
 
 **User (authType="user")**
+
 - Planned for future implementation
 - Would represent authenticated users without admin privileges
 - Currently not fully implemented in the application
@@ -88,7 +91,6 @@ This project uses the Next.js [Pages Router](https://nextjs.org/docs/pages).
     Hook for tracking time spent on a page while visible (excludes time when tab is hidden).
 - **pages/**
   Next.js pages for the app.
-
   - **admin/[*type*]/**
     Administration tools; see [dynamic segments](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes) in Next.js.
     - **[*id*].tsx**
@@ -239,15 +241,14 @@ Open [http://localhost:8080](http://localhost:8080) with your browser to see the
       3. In the LLM Engine [localhost](http://localhost) environment, set token to the value of `access.token` in the login response
    2. Create conversation with channels for moderator/participants
       1. In the response body, you should see a passcode for both the moderator and participant channels (see below for more details)
-4. Before running nextspace locally, be sure to change the `NEXT_PUBLIC_LLM_FCLTR_TOPIC_ID` in your `.env` file. The conversation ID can be found in the response body created in 3b. You can also find it in the Environment view in Postman under the “Current value” column.
-5. When running NextSpace locally, you should now be able to access these channels in your local browser.
+4. When running NextSpace locally, you should now be able to access these channels in your local browser.
 
 > _Note_: A collection of debugging configurations is provided when using VS Code. For help with the debugging in other IDEs or in devtools, see [here](https://nextjs.org/docs/app/guides/debugging).
 
 ### URL formatting convention
 
-NextSpace currently uses the following URL convention when loading either the moderator or back channel view:
-`.../<moderator|backchannel>?conversationId=<ID>&channel=<channel,password>`
+NextSpace currently uses the following URL convention when loading either the moderator or assistant view:
+`.../<moderator|assistant>?conversationId=<ID>&channel=<channel,password>`
 
 So a full example of this on your local instance might look like
 

--- a/__tests__/api/session.test.ts
+++ b/__tests__/api/session.test.ts
@@ -29,7 +29,7 @@ jest.mock("../../utils/withEnvValidation", () => ({
 import handler from "../../pages/api/session";
 import { jwtDecrypt } from "jose";
 
-const SECRET = "test-secret-key-minimum-32-chars!!";
+const SECRET = "bri956LLFxctMUwQYElvu8VcM/hIN/4O6dwGnPLd9WM=";
 process.env.SESSION_SECRET = SECRET;
 Object.defineProperty(process.env, "NODE_ENV", {
   value: "test",

--- a/__tests__/api/session.test.ts
+++ b/__tests__/api/session.test.ts
@@ -42,6 +42,82 @@ const mockJwtDecrypt = jwtDecrypt as jest.MockedFunction<typeof jwtDecrypt>;
 const jose = require("jose");
 const mockEncrypt = jose.__mockEncrypt;
 
+describe("SESSION_SECRET validation", () => {
+  const originalSecret = process.env.SESSION_SECRET;
+
+  afterEach(() => {
+    process.env.SESSION_SECRET = originalSecret;
+  });
+
+  it("should return 500 if SESSION_SECRET is not set", async () => {
+    delete process.env.SESSION_SECRET;
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: { username: "testuser", accessToken: "a", refreshToken: "b" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: "Internal server error: missing environment variable",
+    });
+  });
+
+  it("should return 500 if SESSION_SECRET decodes to wrong byte length", async () => {
+    // base64 of a string that does not decode to 32 bytes
+    process.env.SESSION_SECRET = Buffer.from("tooshort").toString("base64");
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: { username: "testuser", accessToken: "a", refreshToken: "b" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: "Internal server error: invalid environment variable length",
+    });
+  });
+
+  it("should return 500 if SESSION_SECRET is not valid base64 (random chars)", async () => {
+    // Not valid base64, but Buffer.from will still attempt to parse it;
+    // the result will not be 32 bytes
+    process.env.SESSION_SECRET = "not-valid-base64!!!";
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: { username: "testuser", accessToken: "a", refreshToken: "b" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: "Internal server error: invalid environment variable length",
+    });
+  });
+
+  it("should return 500 if SESSION_SECRET is a 44-char base64 string that decodes to wrong length", async () => {
+    // 44 chars of base64 but not a valid 32-byte key (padding issues)
+    process.env.SESSION_SECRET = "YQ==".padEnd(44, "Y"); // invalid padding, not 32 bytes
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: { username: "testuser", accessToken: "a", refreshToken: "b" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(JSON.parse(res._getData())).toEqual({
+      error: "Internal server error: invalid environment variable length",
+    });
+  });
+});
+
 describe("/api/session", () => {
   beforeEach(() => {
     mockEncrypt.mockResolvedValue("encrypted-jwt-token");

--- a/pages/api/session.ts
+++ b/pages/api/session.ts
@@ -13,7 +13,10 @@ import { CURRENT_COOKIE_VERSION } from "../../utils/cookieValidator";
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!process.env.SESSION_SECRET) {
-    res.status(500).json({ error: "SESSION_SECRET is not set" });
+    console.log("SESSION_SECRET is not set");
+    res
+      .status(500)
+      .json({ error: "Internal server error: missing environment variable" });
     return;
   }
 

--- a/pages/api/session.ts
+++ b/pages/api/session.ts
@@ -12,14 +12,22 @@ import { CURRENT_COOKIE_VERSION } from "../../utils/cookieValidator";
  * @returns A JSON response indicating successful cookie operation
  */
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const secret = new TextEncoder().encode(process.env.SESSION_SECRET!);
+  if (!process.env.SESSION_SECRET) {
+    res.status(500).json({ error: "SESSION_SECRET is not set" });
+    return;
+  }
+
+  const secret = Buffer.from(process.env.SESSION_SECRET, "base64");
 
   // Handle PATCH request - update tokens in existing session
   if (req.method === "PATCH") {
-    const { accessToken, refreshToken, accessExpires, refreshExpires } = req.body;
+    const { accessToken, refreshToken, accessExpires, refreshExpires } =
+      req.body;
 
     if (!accessToken || !refreshToken) {
-      res.status(400).json({ error: "accessToken and refreshToken are required" });
+      res
+        .status(400)
+        .json({ error: "accessToken and refreshToken are required" });
       return;
     }
 
@@ -61,7 +69,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         "Set-Cookie",
         `nextspace-session=${cookie}; HttpOnly; ${
           process.env.NODE_ENV === "production" ? "Secure" : ""
-        }; SameSite=Strict; Max-Age=${maxAge}; Path=/`
+        }; SameSite=Strict; Max-Age=${maxAge}; Path=/`,
       );
       res.status(200).json({ message: "Successfully updated session tokens!" });
       return;
@@ -111,7 +119,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       .setExpirationTime(
         sessionData.expirationFromNow
           ? Math.floor(Date.now() / 1000) + sessionData.expirationFromNow
-          : "30d"
+          : "30d",
       )
       .setSubject(sessionData.username)
       .setIssuedAt()
@@ -123,7 +131,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       "Set-Cookie",
       `nextspace-session=${cookie}; HttpOnly; ${
         process.env.NODE_ENV === "production" ? "Secure" : ""
-      }; SameSite=Strict; Max-Age=${maxAge}; Path=/`
+      }; SameSite=Strict; Max-Age=${maxAge}; Path=/`,
     );
     res.status(200).json({ message: "Successfully set cookie!" });
     return;

--- a/pages/api/session.ts
+++ b/pages/api/session.ts
@@ -21,6 +21,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const secret = Buffer.from(process.env.SESSION_SECRET, "base64");
+  if (secret.length !== 32) {
+    console.error(
+      `SESSION_SECRET decoded to ${secret.length} bytes, expected 32`,
+    );
+    res
+      .status(500)
+      .json({
+        error: "Internal server error: invalid environment variable length",
+      });
+    return;
+  }
 
   // Handle PATCH request - update tokens in existing session
   if (req.method === "PATCH") {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -65,7 +65,7 @@ export default function LoginPage() {
     try {
       const response = await Authenticate(
         formData.get("username")!.toString(),
-        formData.get("password")!.toString()
+        formData.get("password")!.toString(),
       );
       if (response.error) {
         setFormError(response.message);
@@ -82,12 +82,12 @@ export default function LoginPage() {
       );
 
       const userId = response.user?.id || response.userId;
-      
+
       // Get the active pseudonym for the user
       const activePseudonym = response.user?.pseudonyms?.find(
-        (p: any) => p.active
+        (p: any) => p.active,
       )?.pseudonym;
-      
+
       if (!activePseudonym) {
         setFormError("No active pseudonym found for user.");
         return;
@@ -98,7 +98,7 @@ export default function LoginPage() {
 
       // Set session cookie via local API route, including expiry timestamps
       // so the cookie-based proactive refresh can schedule correctly.
-      await fetch("/api/session", {
+      const sessionReq = await fetch("/api/session", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -113,7 +113,15 @@ export default function LoginPage() {
           authType: "admin",
         }),
       });
+      // Check if the session request was successful
+      if (!sessionReq.ok) {
+        const errorData = await sessionReq.json();
+        setFormError(errorData.error || "Failed to set session cookie.");
+        return;
+      }
+
       setFormSuccess(true);
+
       // Redirect to events page after successful login
       router.push("/admin/events");
     } catch (error: any) {
@@ -192,9 +200,9 @@ export default function LoginPage() {
               !formRef.current?.elements.namedItem("username") ||
                 !(
                   formRef.current.elements.namedItem(
-                    "username"
+                    "username",
                   ) as HTMLInputElement
-                ).value
+                ).value,
             )
           }
           error={usernameHasError}
@@ -215,9 +223,9 @@ export default function LoginPage() {
               !formRef.current?.elements.namedItem("password") ||
                 !(
                   formRef.current.elements.namedItem(
-                    "password"
+                    "password",
                   ) as HTMLInputElement
-                ).value
+                ).value,
             )
           }
           error={passwordHasError}

--- a/utils/Decrypt.ts
+++ b/utils/Decrypt.ts
@@ -13,6 +13,14 @@ export default async function decryptCookie(
     if (!process.env.SESSION_SECRET) throw new Error("No session secret found");
 
     const secret = Buffer.from(process.env.SESSION_SECRET, "base64");
+
+    if (secret.length !== 32) {
+      console.error(
+        `SESSION_SECRET decoded to ${secret.length} bytes, expected 32`,
+      );
+      throw new Error("Invalid environment variable length");
+    }
+
     const cookie = await jwtDecrypt(token, secret);
     return cookie;
   } catch (error) {

--- a/utils/Decrypt.ts
+++ b/utils/Decrypt.ts
@@ -6,11 +6,13 @@ import { jwtDecrypt } from "jose/jwt/decrypt";
  * @returns The decrypted cookie payload or null if decryption fails
  */
 export default async function decryptCookie(
-  token: string
+  token: string,
 ): Promise<any | null> {
   try {
     if (!token) throw new Error("No token found");
-    const secret = new TextEncoder().encode(process.env.SESSION_SECRET!);
+    if (!process.env.SESSION_SECRET) throw new Error("No session secret found");
+
+    const secret = Buffer.from(process.env.SESSION_SECRET, "base64");
     const cookie = await jwtDecrypt(token, secret);
     return cookie;
   } catch (error) {


### PR DESCRIPTION
## What is in this PR?
- Resolves the error that can occur if the `SESSION_SECRET` provided is a base-64 32-length Crypto key used to encrypt session cookies with A128CBC-HS256 algorithm, as specified in our README. Using such a string (44 characters _before buffering_) would throw a length and mismatch error.
- This error never manifested prior to updating our `SESSION_SECRET` because the previous one was a _text length_ of 32.
- Small README update.

## Changes in the codebase
Where are applicable, replace usage of the TextEncoder interface with the node Buffer API to correctly encode the key as a base-64 buffer. Also catch if the secret is undefined.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] update your `SESSION_SECRET` to be a base-64 32-length Crypto key (44 plain-text length!)
- [ ] note that logging into the admin section of the app works

## Additional information
**Once this PR has been merged to production, we will all have to update the `SESSION_SECRET` env var on to a base-64 32-length Crypto key, both locally and production.**