### PR TITLE
add resources tab with reading recommendations to assistant page

### DIFF
--- a/__tests__/components/NavigationBar.test.tsx
+++ b/__tests__/components/NavigationBar.test.tsx
@@ -10,10 +10,9 @@ const baseProps = {
   unseenChatCount: 0,
   unreadAssistantReplyCount: 0,
   unreadChatReplyCount: 0,
-  unseenJargonCount: 0,
   showChat: true,
   showTranscript: true,
-  showJargon: false,
+  showResources: false,
   botName: "Berkie",
 };
 
@@ -22,13 +21,14 @@ describe("NavigationBar", () => {
     jest.clearAllMocks();
   });
 
-  it("renders all three tabs when showChat and showTranscript are true", () => {
+  it("renders assistant, chat, and transcript tabs when showChat and showTranscript are true", () => {
     render(<NavigationBar {...baseProps} />);
 
     // Both desktop and mobile navs render, so use getAllByLabelText
     expect(screen.getAllByLabelText("Berkie").length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Group Chat").length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText("Transcript").length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText("Resources")).not.toBeInTheDocument();
   });
 
   it("hides chat tab when showChat is false", () => {
@@ -55,6 +55,42 @@ describe("NavigationBar", () => {
     expect(screen.getAllByLabelText("Berkie").length).toBeGreaterThan(0);
     expect(screen.queryByLabelText("Group Chat")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Transcript")).not.toBeInTheDocument();
+  });
+
+  it("hides resources tab by default", () => {
+    render(<NavigationBar {...baseProps} />);
+
+    expect(screen.queryByLabelText("Resources")).not.toBeInTheDocument();
+  });
+
+  it("shows resources tab when showResources is true", () => {
+    render(<NavigationBar {...baseProps} showResources={true} />);
+
+    expect(screen.getAllByLabelText("Resources").length).toBeGreaterThan(0);
+  });
+
+  it("calls onTabChange with 'resources' when resources tab clicked", async () => {
+    const user = userEvent.setup();
+    const onTabChange = jest.fn();
+    render(
+      <NavigationBar {...baseProps} showResources={true} onTabChange={onTabChange} />,
+    );
+
+    const resourcesBtns = screen.getAllByLabelText("Resources");
+    await user.click(resourcesBtns[0]);
+
+    expect(onTabChange).toHaveBeenCalledWith("resources");
+  });
+
+  it("marks resources tab as active with aria-current='page' when activeTab is resources", () => {
+    render(
+      <NavigationBar {...baseProps} showResources={true} activeTab="resources" />,
+    );
+
+    const activeResourcesBtns = screen
+      .getAllByLabelText("Resources")
+      .filter((btn) => btn.getAttribute("aria-current") === "page");
+    expect(activeResourcesBtns.length).toBeGreaterThan(0);
   });
 
   it("marks the active tab with aria-current='page'", () => {
@@ -174,6 +210,42 @@ describe("NavigationBar", () => {
           !(badge as HTMLElement).classList.contains("MuiBadge-invisible"),
       );
       expect(visibleBadges.length).toBeGreaterThan(0);
+    });
+
+    it("shows badge on resources tab when unseenResourcesCount > 0 and not on resources tab", () => {
+      const { container } = render(
+        <NavigationBar
+          {...baseProps}
+          showResources={true}
+          unseenResourcesCount={3}
+          activeTab="assistant"
+        />,
+      );
+
+      const badges = container.querySelectorAll(".MuiBadge-badge");
+      const visibleBadges = Array.from(badges).filter(
+        (badge) =>
+          !(badge as HTMLElement).classList.contains("MuiBadge-invisible"),
+      );
+      expect(visibleBadges.length).toBeGreaterThan(0);
+    });
+
+    it("hides badge on resources tab when active even with unseenResourcesCount > 0", () => {
+      const { container } = render(
+        <NavigationBar
+          {...baseProps}
+          showResources={true}
+          unseenResourcesCount={3}
+          activeTab="resources"
+        />,
+      );
+
+      const badges = container.querySelectorAll(".MuiBadge-badge");
+      const visibleBadges = Array.from(badges).filter(
+        (badge) =>
+          !(badge as HTMLElement).classList.contains("MuiBadge-invisible"),
+      );
+      expect(visibleBadges.length).toBe(0);
     });
 
     it("shows badge when on chat tab with unseenChatCount but no unreadChatReplyCount", () => {

--- a/__tests__/components/ResourcesPanel.test.tsx
+++ b/__tests__/components/ResourcesPanel.test.tsx
@@ -368,7 +368,7 @@ describe("ResourcesPanel", () => {
   });
 
   describe("onMarkReadingsAsSeen callback", () => {
-    it("calls onMarkReadingsAsSeen when readings section is expanded", async () => {
+    it("does not call onMarkReadingsAsSeen when readings section is expanded", async () => {
       const user = userEvent.setup();
       const onMarkReadingsAsSeen = jest.fn();
       render(
@@ -378,10 +378,10 @@ describe("ResourcesPanel", () => {
         />,
       );
       await user.click(screen.getByText("Readings & References"));
-      expect(onMarkReadingsAsSeen).toHaveBeenCalledTimes(1);
+      expect(onMarkReadingsAsSeen).not.toHaveBeenCalled();
     });
 
-    it("does not call onMarkReadingsAsSeen when collapsing readings section", async () => {
+    it("calls onMarkReadingsAsSeen when collapsing readings section", async () => {
       const user = userEvent.setup();
       const onMarkReadingsAsSeen = jest.fn();
       render(

--- a/__tests__/components/ResourcesPanel.test.tsx
+++ b/__tests__/components/ResourcesPanel.test.tsx
@@ -1,0 +1,537 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ResourcesPanel } from "../../components/ResourcesPanel";
+import { PseudonymousMessage } from "../../types.internal";
+
+// Mock parseMessageBody from Helpers
+jest.mock("../../utils/Helpers", () => ({
+  parseMessageBody: jest.fn(),
+}));
+
+import { parseMessageBody } from "../../utils/Helpers";
+const mockParseMessageBody = parseMessageBody as jest.Mock;
+
+function makeMessage(body: any): PseudonymousMessage {
+  return { id: "msg-1", body } as unknown as PseudonymousMessage;
+}
+
+const readingMessage = makeMessage({
+  type: "reading",
+  content: [
+    {
+      title: "The Internet and Democracy",
+      authors: ["Jane Doe", "John Smith"],
+      year: 2021,
+      abstract: "An abstract about internet and democracy.",
+      relevanceReason: "Directly relevant to today's discussion.",
+    },
+  ],
+});
+
+const readingMessageNoOptionals = makeMessage({
+  type: "reading",
+  content: [
+    {
+      title: "Digital Governance",
+      authors: ["Alice Wang"],
+      year: 2019,
+    },
+  ],
+});
+
+describe("ResourcesPanel", () => {
+  beforeEach(() => {
+    mockParseMessageBody.mockReturnValue({ text: "", type: undefined });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("header / event info", () => {
+    it("renders default title when eventName is not provided", () => {
+      render(<ResourcesPanel messages={[]} />);
+      expect(screen.getByText("Event Resources")).toBeInTheDocument();
+    });
+
+    it("renders eventName when provided", () => {
+      render(<ResourcesPanel messages={[]} eventName="Tech & Society Forum" />);
+      expect(screen.getByText("Tech & Society Forum")).toBeInTheDocument();
+    });
+
+    it("renders short eventDescription without truncation controls", () => {
+      render(
+        <ResourcesPanel messages={[]} eventDescription="Short description." />,
+      );
+      expect(screen.getByText("Short description.")).toBeInTheDocument();
+      expect(screen.queryByText("more")).not.toBeInTheDocument();
+    });
+
+    it("truncates long eventDescription and shows 'more' button", () => {
+      const longDescription = "A".repeat(600);
+      render(
+        <ResourcesPanel messages={[]} eventDescription={longDescription} />,
+      );
+      expect(screen.getByText("more")).toBeInTheDocument();
+      expect(screen.queryByText("less")).not.toBeInTheDocument();
+    });
+
+    it("expands truncated eventDescription on 'more' click and shows 'less'", async () => {
+      const user = userEvent.setup();
+      const longDescription = "A".repeat(600);
+      render(
+        <ResourcesPanel messages={[]} eventDescription={longDescription} />,
+      );
+      await user.click(screen.getByText("more"));
+      expect(screen.getByText("less")).toBeInTheDocument();
+      expect(screen.queryByText("more")).not.toBeInTheDocument();
+    });
+
+    it("collapses expanded description back on 'less' click", async () => {
+      const user = userEvent.setup();
+      const longDescription = "B".repeat(600);
+      render(
+        <ResourcesPanel messages={[]} eventDescription={longDescription} />,
+      );
+      await user.click(screen.getByText("more"));
+      await user.click(screen.getByText("less"));
+      expect(screen.getByText("more")).toBeInTheDocument();
+    });
+  });
+
+  describe("category headers", () => {
+    it("renders Speakers and Readings & References category headers", () => {
+      render(<ResourcesPanel messages={[]} />);
+      expect(screen.getByText("Speakers")).toBeInTheDocument();
+      expect(screen.getByText("Readings & References")).toBeInTheDocument();
+    });
+
+    it("categories are collapsed by default (content not visible)", () => {
+      render(
+        <ResourcesPanel
+          messages={[]}
+          speakers={[{ name: "Alice", bio: "Bio here" }]}
+        />,
+      );
+      expect(
+        screen.queryByText("Speakers", { selector: "h4" }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Alice")).not.toBeInTheDocument();
+    });
+
+    it("shows ExpandMore icon when collapsed and ExpandLess when expanded", async () => {
+      const user = userEvent.setup();
+      render(<ResourcesPanel messages={[]} />);
+      // MUI renders icons with data-testid like "ExpandMoreIcon"
+      expect(screen.getAllByTestId("ExpandMoreIcon")).toHaveLength(2);
+
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.getAllByTestId("ExpandLessIcon")).toHaveLength(1);
+    });
+  });
+
+  describe("Speakers section", () => {
+    it("shows speakers when the Speakers category is expanded", async () => {
+      const user = userEvent.setup();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          speakers={[
+            { name: "Dr. Ada Lovelace", bio: "Pioneer of computing." },
+          ]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.getByText("Dr. Ada Lovelace")).toBeInTheDocument();
+      expect(screen.getByText("Pioneer of computing.")).toBeInTheDocument();
+    });
+
+    it("shows moderators when expanded", async () => {
+      const user = userEvent.setup();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          moderators={[{ name: "Mod One", bio: "Moderator bio." }]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.getByText("Moderators")).toBeInTheDocument();
+      expect(screen.getByText("Mod One")).toBeInTheDocument();
+    });
+
+    it("shows both moderators and speakers sections when both are provided", async () => {
+      const user = userEvent.setup();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          speakers={[{ name: "Speaker A", bio: "Speaker bio." }]}
+          moderators={[{ name: "Mod B", bio: "Mod bio." }]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.getByText("Moderators")).toBeInTheDocument();
+      expect(
+        screen.getByText("Speakers", { selector: "h4" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Speaker A")).toBeInTheDocument();
+      expect(screen.getByText("Mod B")).toBeInTheDocument();
+    });
+
+    it("does not render Moderators sub-heading when moderators array is empty", async () => {
+      const user = userEvent.setup();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          speakers={[{ name: "Speaker A", bio: "Bio." }]}
+          moderators={[]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.queryByText("Moderators")).not.toBeInTheDocument();
+    });
+
+    it("truncates long speaker bios and allows expansion", async () => {
+      const user = userEvent.setup();
+      const longBio = "X".repeat(400);
+      render(
+        <ResourcesPanel
+          messages={[]}
+          speakers={[{ name: "Speaker A", bio: longBio }]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.getByText("more")).toBeInTheDocument();
+      await user.click(screen.getByText("more"));
+      expect(screen.getByText("less")).toBeInTheDocument();
+    });
+
+    it("collapses the speakers section when header is clicked again", async () => {
+      const user = userEvent.setup();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          speakers={[{ name: "Speaker A", bio: "Bio." }]}
+        />,
+      );
+      // Click the category header button to expand
+      await user.click(screen.getByRole("button", { name: /speakers/i }));
+      expect(screen.getByText("Speaker A")).toBeInTheDocument();
+      // Click again to collapse — re-query to get a fresh reference
+      await user.click(screen.getByRole("button", { name: /speakers/i }));
+      expect(screen.queryByText("Speaker A")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Readings & References section", () => {
+    it("shows empty state when there are no readings", async () => {
+      const user = userEvent.setup();
+      render(<ResourcesPanel messages={[]} />);
+      await user.click(screen.getByText("Readings & References"));
+      expect(
+        screen.getByText("No reading recommendations available yet."),
+      ).toBeInTheDocument();
+    });
+
+    it("displays readings parsed from messages", async () => {
+      const user = userEvent.setup();
+      mockParseMessageBody.mockReturnValueOnce({
+        text: "",
+        type: "reading",
+        content: [
+          {
+            title: "The Internet and Democracy",
+            authors: ["Jane Doe", "John Smith"],
+            year: 2021,
+            abstract: "An abstract about internet and democracy.",
+            relevanceReason: "Directly relevant to today's discussion.",
+          },
+        ],
+      });
+
+      render(<ResourcesPanel messages={[readingMessage]} />);
+      await user.click(screen.getByText("Readings & References"));
+
+      expect(
+        screen.getByText("The Internet and Democracy"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Jane Doe, John Smith (2021)"),
+      ).toBeInTheDocument();
+      // relevanceReason takes priority over abstract when both are present
+      expect(
+        screen.getByText("Directly relevant to today's discussion."),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("An abstract about internet and democracy."),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("AI Pick")).toBeInTheDocument();
+    });
+
+    it("renders reading without optional abstract and relevanceReason", async () => {
+      const user = userEvent.setup();
+      mockParseMessageBody.mockReturnValueOnce({
+        text: "",
+        type: "reading",
+        content: [
+          {
+            title: "Digital Governance",
+            authors: ["Alice Wang"],
+            year: 2019,
+          },
+        ],
+      });
+
+      render(<ResourcesPanel messages={[readingMessageNoOptionals]} />);
+      await user.click(screen.getByText("Readings & References"));
+
+      expect(screen.getByText("Digital Governance")).toBeInTheDocument();
+      expect(screen.getByText("Alice Wang (2019)")).toBeInTheDocument();
+      expect(screen.queryByText("Why it's relevant:")).not.toBeInTheDocument();
+    });
+
+    it("aggregates readings from multiple messages", async () => {
+      const msg1 = makeMessage({ type: "reading", content: [{ title: "Book One", authors: ["Author A"], year: 2020 }] });
+      const msg2 = makeMessage({ type: "reading", content: [{ title: "Book Two", authors: ["Author B"], year: 2022 }] });
+
+      mockParseMessageBody
+        .mockReturnValueOnce({
+          text: "",
+          type: "reading",
+          content: [{ title: "Book One", authors: ["Author A"], year: 2020 }],
+        })
+        .mockReturnValueOnce({
+          text: "",
+          type: "reading",
+          content: [{ title: "Book Two", authors: ["Author B"], year: 2022 }],
+        });
+
+      const user = userEvent.setup();
+      render(<ResourcesPanel messages={[msg1, msg2]} />);
+      await user.click(screen.getByText("Readings & References"));
+
+      expect(screen.getByText("Book One")).toBeInTheDocument();
+      expect(screen.getByText("Book Two")).toBeInTheDocument();
+    });
+
+    it("ignores non-reading messages", async () => {
+      const nonReadingMsg = makeMessage({ type: "assistant", text: "Hello" });
+      mockParseMessageBody.mockReturnValueOnce({
+        text: "Hello",
+        type: "assistant",
+      });
+
+      const user = userEvent.setup();
+      render(<ResourcesPanel messages={[nonReadingMsg]} />);
+      await user.click(screen.getByText("Readings & References"));
+
+      expect(
+        screen.getByText("No reading recommendations available yet."),
+      ).toBeInTheDocument();
+    });
+
+    it("collapses the readings section when clicked again", async () => {
+      const user = userEvent.setup();
+      render(<ResourcesPanel messages={[]} />);
+      await user.click(screen.getByText("Readings & References"));
+      expect(
+        screen.getByText("No reading recommendations available yet."),
+      ).toBeInTheDocument();
+      await user.click(screen.getByText("Readings & References"));
+      expect(
+        screen.queryByText("No reading recommendations available yet."),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("unseenReadingsCount badge", () => {
+    it("does not show badge when unseenReadingsCount is 0", () => {
+      render(<ResourcesPanel messages={[]} unseenReadingsCount={0} />);
+      expect(screen.queryByText("0")).not.toBeInTheDocument();
+    });
+
+    it("shows badge with count when unseenReadingsCount > 0", () => {
+      render(<ResourcesPanel messages={[]} unseenReadingsCount={3} />);
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("does not show badge for the Speakers category regardless", () => {
+      render(
+        <ResourcesPanel
+          messages={[]}
+          unseenReadingsCount={5}
+          speakers={[{ name: "S", bio: "B" }]}
+        />,
+      );
+      // Badge "5" should appear once (Readings), not duplicated for Speakers
+      expect(screen.getAllByText("5")).toHaveLength(1);
+    });
+  });
+
+  describe("onMarkReadingsAsSeen callback", () => {
+    it("calls onMarkReadingsAsSeen when readings section is expanded", async () => {
+      const user = userEvent.setup();
+      const onMarkReadingsAsSeen = jest.fn();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          onMarkReadingsAsSeen={onMarkReadingsAsSeen}
+        />,
+      );
+      await user.click(screen.getByText("Readings & References"));
+      expect(onMarkReadingsAsSeen).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onMarkReadingsAsSeen when collapsing readings section", async () => {
+      const user = userEvent.setup();
+      const onMarkReadingsAsSeen = jest.fn();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          onMarkReadingsAsSeen={onMarkReadingsAsSeen}
+        />,
+      );
+      await user.click(screen.getByText("Readings & References")); // expand
+      await user.click(screen.getByText("Readings & References")); // collapse
+      expect(onMarkReadingsAsSeen).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onMarkReadingsAsSeen when expanding the Speakers section", async () => {
+      const user = userEvent.setup();
+      const onMarkReadingsAsSeen = jest.fn();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          onMarkReadingsAsSeen={onMarkReadingsAsSeen}
+          speakers={[{ name: "S", bio: "B" }]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(onMarkReadingsAsSeen).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when onMarkReadingsAsSeen is not provided", async () => {
+      const user = userEvent.setup();
+      render(<ResourcesPanel messages={[]} />);
+      await expect(
+        user.click(screen.getByText("Readings & References")),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("newReadingMessageIds highlighting", () => {
+    it("shows 'New' badge on readings whose messageId is in newReadingMessageIds", async () => {
+      const user = userEvent.setup();
+      mockParseMessageBody.mockReturnValueOnce({
+        text: "",
+        type: "reading",
+        content: [{ title: "New Paper", authors: ["Author X"], year: 2024 }],
+      });
+
+      render(
+        <ResourcesPanel
+          messages={[readingMessage]}
+          newReadingMessageIds={new Set(["msg-1"])}
+        />,
+      );
+      await user.click(screen.getByText("Readings & References"));
+      expect(screen.getByText("New")).toBeInTheDocument();
+    });
+
+    it("does not show 'New' badge when messageId is not in newReadingMessageIds", async () => {
+      const user = userEvent.setup();
+      mockParseMessageBody.mockReturnValueOnce({
+        text: "",
+        type: "reading",
+        content: [{ title: "Old Paper", authors: ["Author Y"], year: 2020 }],
+      });
+
+      render(
+        <ResourcesPanel
+          messages={[readingMessage]}
+          newReadingMessageIds={new Set(["other-msg-id"])}
+        />,
+      );
+      await user.click(screen.getByText("Readings & References"));
+      expect(screen.queryByText("New")).not.toBeInTheDocument();
+    });
+
+    it("does not show 'New' badge when newReadingMessageIds is not provided", async () => {
+      const user = userEvent.setup();
+      mockParseMessageBody.mockReturnValueOnce({
+        text: "",
+        type: "reading",
+        content: [{ title: "Some Paper", authors: ["Author Z"], year: 2022 }],
+      });
+
+      render(<ResourcesPanel messages={[readingMessage]} />);
+      await user.click(screen.getByText("Readings & References"));
+      expect(screen.queryByText("New")).not.toBeInTheDocument();
+    });
+
+    it("applies amber styling only to new readings, not all readings", async () => {
+      const user = userEvent.setup();
+      const msg1 = { id: "msg-new", body: {} } as unknown as PseudonymousMessage;
+      const msg2 = { id: "msg-old", body: {} } as unknown as PseudonymousMessage;
+
+      mockParseMessageBody
+        .mockReturnValueOnce({
+          text: "",
+          type: "reading",
+          content: [{ title: "New Reading", authors: ["A"], year: 2024 }],
+        })
+        .mockReturnValueOnce({
+          text: "",
+          type: "reading",
+          content: [{ title: "Old Reading", authors: ["B"], year: 2020 }],
+        });
+
+      render(
+        <ResourcesPanel
+          messages={[msg1, msg2]}
+          newReadingMessageIds={new Set(["msg-new"])}
+        />,
+      );
+      await user.click(screen.getByText("Readings & References"));
+
+      expect(screen.getByText("New")).toBeInTheDocument();
+      // Only one "New" badge even though there are two readings
+      expect(screen.getAllByText("New")).toHaveLength(1);
+    });
+  });
+
+  describe("multiple speakers and moderators", () => {
+    it("renders all speakers", async () => {
+      const user = userEvent.setup();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          speakers={[
+            { name: "Speaker One", bio: "Bio one." },
+            { name: "Speaker Two", bio: "Bio two." },
+            { name: "Speaker Three", bio: "Bio three." },
+          ]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.getByText("Speaker One")).toBeInTheDocument();
+      expect(screen.getByText("Speaker Two")).toBeInTheDocument();
+      expect(screen.getByText("Speaker Three")).toBeInTheDocument();
+    });
+
+    it("renders all moderators", async () => {
+      const user = userEvent.setup();
+      render(
+        <ResourcesPanel
+          messages={[]}
+          moderators={[
+            { name: "Mod Alpha", bio: "Alpha bio." },
+            { name: "Mod Beta", bio: "Beta bio." },
+          ]}
+        />,
+      );
+      await user.click(screen.getByText("Speakers"));
+      expect(screen.getByText("Mod Alpha")).toBeInTheDocument();
+      expect(screen.getByText("Mod Beta")).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -2298,4 +2298,368 @@ describe("EventAssistantRoom", () => {
       // "Option A" marked as selected
     });
   });
+
+  describe("Resources channel", () => {
+    const resourcesSetup = async () => {
+      mockRouter.query = {
+        conversationId: "test-conversation-id",
+        channel: "resources,resources-pass",
+      };
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        } else if (path.includes("?channel=resources,")) {
+          return Promise.resolve([]);
+        } else if (path.startsWith("messages/")) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve(null);
+      });
+
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+        name: "Tech Forum",
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
+    };
+
+    /** Grab the most recently registered message:new handler from the socket mock. */
+    const getMessageHandler = (): Function => {
+      const handler = mockSocket.on.mock.calls
+        .filter(([event]: [string]) => event === "message:new")
+        .map(([, h]: [string, Function]) => h)
+        .at(-1)!;
+      expect(handler).toBeDefined();
+      return handler;
+    };
+
+    it("includes resources channel in conversation:join when resourcesPasscode is set", async () => {
+      await resourcesSetup();
+
+      await waitFor(() => {
+        expect(mockSocket.emit).toHaveBeenCalledWith(
+          "conversation:join",
+          expect.objectContaining({
+            channels: expect.arrayContaining([
+              { name: "resources", passcode: "resources-pass", direct: false },
+            ]),
+          }),
+        );
+      });
+    });
+
+    it("fetches initial resources messages when resourcesPasscode is available", async () => {
+      await resourcesSetup();
+
+      await waitFor(() => {
+        expect(RetrieveData).toHaveBeenCalledWith(
+          "messages/test-conversation-id?channel=resources,resources-pass",
+          "mock-access-token",
+        );
+      });
+    });
+
+    it("populates resourcesMessages from initial fetch", async () => {
+      const mockResourcesMessages = [
+        {
+          id: "res-1",
+          body: { type: "reading", content: [{ title: "Book A", authors: ["A"], year: 2020 }] },
+          channels: ["resources"],
+        },
+      ];
+
+      mockRouter.query = {
+        conversationId: "test-conversation-id",
+        channel: "resources,resources-pass",
+      };
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        } else if (path.includes("?channel=resources,")) {
+          return Promise.resolve(mockResourcesMessages);
+        }
+        return Promise.resolve([]);
+      });
+
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+        name: "Tech Forum",
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() => {
+        expect(RetrieveData).toHaveBeenCalledWith(
+          "messages/test-conversation-id?channel=resources,resources-pass",
+          "mock-access-token",
+        );
+      });
+    });
+
+    it("routes incoming socket message with resources channel to resourcesMessages", async () => {
+      await resourcesSetup();
+
+      const user = userEvent.setup();
+      // Navigate to resources tab so the panel renders
+      const resourcesTab = screen.getAllByLabelText("Resources")[0];
+      await user.click(resourcesTab);
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+      });
+
+      const messageHandler = getMessageHandler();
+
+      act(() => {
+        messageHandler({
+          id: "res-msg-1",
+          body: { type: "reading", content: [] },
+          channels: ["resources"],
+          pseudonym: "System",
+        });
+      });
+
+      // The ResourcesPanel should still be visible after the message arrives
+      await waitFor(() => {
+        expect(screen.getByText("Readings & References")).toBeInTheDocument();
+      });
+    });
+
+    it("increments unseenResourcesCount when a resources message arrives and the resources tab is NOT active", async () => {
+      await resourcesSetup();
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+      });
+
+      const messageHandler = getMessageHandler();
+
+      // Default tab is chat — unseen count should increment, showing the dot badge
+      act(() => {
+        messageHandler({ id: "res-1", channels: ["resources"], body: { type: "reading", content: [{ title: "Book A", authors: ["Author"], year: 2020 }] } });
+      });
+
+      // NavigationBar uses MUI Badge dot variant — a visible badge has no MuiBadge-invisible class
+      await waitFor(() => {
+        const badges = document.querySelectorAll(".MuiBadge-badge");
+        const visibleBadges = Array.from(badges).filter(
+          (b) => !b.classList.contains("MuiBadge-invisible"),
+        );
+        expect(visibleBadges.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("does NOT increment unseenResourcesCount when a resources message arrives and resources tab IS active", async () => {
+      await resourcesSetup();
+
+      const user = userEvent.setup();
+      await user.click(screen.getAllByLabelText("Resources")[0]);
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+      });
+
+      const messageHandler = getMessageHandler();
+
+      act(() => {
+        messageHandler({ id: "res-1", channels: ["resources"], body: { type: "reading", content: [] } });
+      });
+
+      // No dot badge should be visible since we're already on the resources tab
+      await waitFor(() => {
+        const badges = document.querySelectorAll(".MuiBadge-badge");
+        const visibleBadges = Array.from(badges).filter(
+          (b) => !b.classList.contains("MuiBadge-invisible"),
+        );
+        expect(visibleBadges.length).toBe(0);
+      });
+    });
+
+    it("resets unseenResourcesCount to 0 when switching to the resources tab", async () => {
+      await resourcesSetup();
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+      });
+
+      const messageHandler = getMessageHandler();
+
+      // Deliver a message while on another tab to bump the count
+      act(() => {
+        messageHandler({ id: "res-1", channels: ["resources"], body: {} });
+      });
+
+      // Badge dot should be visible
+      await waitFor(() => {
+        const badges = document.querySelectorAll(".MuiBadge-badge");
+        const visibleBadges = Array.from(badges).filter(
+          (b) => !b.classList.contains("MuiBadge-invisible"),
+        );
+        expect(visibleBadges.length).toBeGreaterThan(0);
+      });
+
+      // Switch to resources tab — count clears, badge becomes invisible
+      const user = userEvent.setup();
+      await user.click(screen.getAllByLabelText("Resources")[0]);
+
+      await waitFor(() => {
+        const badges = document.querySelectorAll(".MuiBadge-badge");
+        const visibleBadges = Array.from(badges).filter(
+          (b) => !b.classList.contains("MuiBadge-invisible"),
+        );
+        expect(visibleBadges.length).toBe(0);
+      });
+    });
+
+    it("renders ResourcesPanel when resources tab is active", async () => {
+      await resourcesSetup();
+
+      const user = userEvent.setup();
+      await user.click(screen.getAllByLabelText("Resources")[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText("Readings & References")).toBeInTheDocument();
+      });
+    });
+
+    it("does NOT route resources messages to assistantMessages or chatMessages", async () => {
+      await resourcesSetup();
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+      });
+
+      const messageHandler = getMessageHandler();
+
+      act(() => {
+        messageHandler({ id: "res-1", channels: ["resources"], body: { text: "Resources only" } });
+      });
+
+      // Switch to assistant tab and confirm the message isn't rendered there
+      const user = userEvent.setup();
+      await user.click(screen.getAllByLabelText("Berkie")[0]);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Resources only")).not.toBeInTheDocument();
+      });
+    });
+
+    it("increments unseenResourcesCount by the number of items in a multi-item reading message", async () => {
+      await resourcesSetup();
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+      });
+
+      const messageHandler = getMessageHandler();
+
+      // Message with 3 reading items — count should go up by 3, not 1
+      act(() => {
+        messageHandler({
+          id: "res-multi",
+          channels: ["resources"],
+          body: {
+            type: "reading",
+            content: [
+              { title: "Book A", authors: ["A"], year: 2020 },
+              { title: "Book B", authors: ["B"], year: 2021 },
+              { title: "Book C", authors: ["C"], year: 2022 },
+            ],
+          },
+        });
+      });
+
+      // Switch to resources tab to see the reset value, confirming the count was > 1
+      // by checking badge was visible before switching
+      await waitFor(() => {
+        const badges = document.querySelectorAll(".MuiBadge-badge");
+        const visibleBadges = Array.from(badges).filter(
+          (b) => !b.classList.contains("MuiBadge-invisible"),
+        );
+        expect(visibleBadges.length).toBeGreaterThan(0);
+      });
+
+      // Switch to resources tab — count resets to 0 (confirming it was > 0)
+      const user = userEvent.setup();
+      await user.click(screen.getAllByLabelText("Resources")[0]);
+
+      await waitFor(() => {
+        const badges = document.querySelectorAll(".MuiBadge-badge");
+        const visibleBadges = Array.from(badges).filter(
+          (b) => !b.classList.contains("MuiBadge-invisible"),
+        );
+        expect(visibleBadges.length).toBe(0);
+      });
+    });
+
+    it("Resources tab is always present in the nav even without a resourcesPasscode", async () => {
+      mockRouter.query = { conversationId: "test-conversation-id" };
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        }
+        return Promise.resolve([]);
+      });
+
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
+
+      expect(screen.getAllByLabelText("Resources").length).toBeGreaterThan(0);
+    });
+
+    it("does not fetch resources messages when no resourcesPasscode is provided", async () => {
+      mockRouter.query = { conversationId: "test-conversation-id" };
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        }
+        return Promise.resolve([]);
+      });
+
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
+
+      const resourcesFetch = (RetrieveData as jest.Mock).mock.calls.find(
+        ([path]: [string]) => path.includes("channel=resources"),
+      );
+      expect(resourcesFetch).toBeUndefined();
+    });
+  });
 });

--- a/__tests__/utils/Helpers.test.ts
+++ b/__tests__/utils/Helpers.test.ts
@@ -3,13 +3,18 @@ import {
   normalizeAssistantPseudonym,
   buildDirectChannels,
   parseMessageBody,
+  createConversationFromData,
+  GetChannelPasscode,
+  Api,
 } from "../../utils/Helpers";
 
 describe("resolveConversationBotName", () => {
   const fallback = "Berkie";
 
   it("returns configBotName when agents array is empty", () => {
-    expect(resolveConversationBotName({ agents: [] as any }, fallback)).toBe("Berkie");
+    expect(resolveConversationBotName({ agents: [] as any }, fallback)).toBe(
+      "Berkie",
+    );
   });
 
   it("returns configBotName when first agent has no agentConfig", () => {
@@ -18,13 +23,23 @@ describe("resolveConversationBotName", () => {
   });
 
   it("returns configBotName when agentConfig exists but has no botName key", () => {
-    const agents = [{ id: "a1", agentType: "eventAssistant", agentConfig: { llmModel: "gpt-4" } }] as any;
+    const agents = [
+      {
+        id: "a1",
+        agentType: "eventAssistant",
+        agentConfig: { llmModel: "gpt-4" },
+      },
+    ] as any;
     expect(resolveConversationBotName({ agents }, fallback)).toBe("Berkie");
   });
 
   it("returns agentConfig.botName when it is a non-empty string", () => {
     const agents = [
-      { id: "a1", agentType: "eventAssistant", agentConfig: { botName: "EventBot" } },
+      {
+        id: "a1",
+        agentType: "eventAssistant",
+        agentConfig: { botName: "EventBot" },
+      },
     ] as any;
     expect(resolveConversationBotName({ agents }, fallback)).toBe("EventBot");
   });
@@ -60,7 +75,11 @@ describe("resolveConversationBotName", () => {
   it("uses the first agent only, ignoring subsequent agents", () => {
     const agents = [
       { id: "a1", agentType: "eventAssistant", agentConfig: {} },
-      { id: "a2", agentType: "eventAssistant", agentConfig: { botName: "SecondBot" } },
+      {
+        id: "a2",
+        agentType: "eventAssistant",
+        agentConfig: { botName: "SecondBot" },
+      },
     ] as any;
     // First agent has no botName → falls back to config
     expect(resolveConversationBotName({ agents }, fallback)).toBe("Berkie");
@@ -68,8 +87,16 @@ describe("resolveConversationBotName", () => {
 
   it("uses the first agent's botName when both agents have botName", () => {
     const agents = [
-      { id: "a1", agentType: "eventAssistant", agentConfig: { botName: "FirstBot" } },
-      { id: "a2", agentType: "eventAssistant", agentConfig: { botName: "SecondBot" } },
+      {
+        id: "a1",
+        agentType: "eventAssistant",
+        agentConfig: { botName: "FirstBot" },
+      },
+      {
+        id: "a2",
+        agentType: "eventAssistant",
+        agentConfig: { botName: "SecondBot" },
+      },
     ] as any;
     expect(resolveConversationBotName({ agents }, fallback)).toBe("FirstBot");
   });
@@ -117,10 +144,7 @@ describe("buildDirectChannels", () => {
   const userId = "user-123";
 
   it("includes a direct channel for each agent with no preferenceKey", () => {
-    const agents = [
-      { agentId: "agent-abc" },
-      { agentId: "agent-def" },
-    ];
+    const agents = [{ agentId: "agent-abc" }, { agentId: "agent-def" }];
     const channels = buildDirectChannels(userId, agents, {});
     expect(channels).toHaveLength(2);
     expect(channels.map((c) => c.name)).toContain("direct-user-123-agent-abc");
@@ -132,9 +156,13 @@ describe("buildDirectChannels", () => {
       { agentId: "agent-abc" },
       { agentId: "agent-jargon", preferenceKey: "jargonClarification" },
     ];
-    const channels = buildDirectChannels(userId, agents, { jargonClarification: true });
+    const channels = buildDirectChannels(userId, agents, {
+      jargonClarification: true,
+    });
     expect(channels).toHaveLength(2);
-    expect(channels.map((c) => c.name)).toContain("direct-user-123-agent-jargon");
+    expect(channels.map((c) => c.name)).toContain(
+      "direct-user-123-agent-jargon",
+    );
   });
 
   it("excludes a preference-gated agent channel when the preference is false", () => {
@@ -142,9 +170,13 @@ describe("buildDirectChannels", () => {
       { agentId: "agent-abc" },
       { agentId: "agent-jargon", preferenceKey: "jargonClarification" },
     ];
-    const channels = buildDirectChannels(userId, agents, { jargonClarification: false });
+    const channels = buildDirectChannels(userId, agents, {
+      jargonClarification: false,
+    });
     expect(channels).toHaveLength(1);
-    expect(channels.map((c) => c.name)).not.toContain("direct-user-123-agent-jargon");
+    expect(channels.map((c) => c.name)).not.toContain(
+      "direct-user-123-agent-jargon",
+    );
   });
 
   it("excludes a preference-gated agent channel when the preference is absent", () => {
@@ -154,7 +186,9 @@ describe("buildDirectChannels", () => {
     ];
     const channels = buildDirectChannels(userId, agents, {});
     expect(channels).toHaveLength(1);
-    expect(channels.map((c) => c.name)).not.toContain("direct-user-123-agent-jargon");
+    expect(channels.map((c) => c.name)).not.toContain(
+      "direct-user-123-agent-jargon",
+    );
   });
 
   it("marks all channels as direct with null passcode — access is controlled by channel name, not passcode", () => {
@@ -181,7 +215,10 @@ describe("parseMessageBody", () => {
   });
 
   it("parses object body with type field", () => {
-    const result = parseMessageBody({ text: "Message", type: "moderator_submitted" });
+    const result = parseMessageBody({
+      text: "Message",
+      type: "moderator_submitted",
+    });
     expect(result.text).toBe("Message");
     expect(result.type).toBe("moderator_submitted");
   });
@@ -229,18 +266,21 @@ describe("parseMessageBody", () => {
 
   it("parses all fields together", () => {
     const media = [{ type: "image", data: "data", mimeType: "image/png" }];
+    const content = [{ foo: "bar" }];
     const result = parseMessageBody({
       text: "Complete message",
       type: "multimodal",
       message: "msg-123",
       media,
       sourceMessage: "msg-456",
+      content,
     });
     expect(result.text).toBe("Complete message");
     expect(result.type).toBe("multimodal");
     expect(result.message).toBe("msg-123");
     expect(result.media).toEqual(media);
     expect(result.sourceMessage).toBe("msg-456");
+    expect(result.content).toEqual(content);
   });
 
   it("converts non-string values to string for text field", () => {
@@ -261,5 +301,161 @@ describe("parseMessageBody", () => {
   it("converts non-string values to string for sourceMessage field", () => {
     const result = parseMessageBody({ text: "Message", sourceMessage: 999 });
     expect(result.sourceMessage).toBe("999");
+  });
+});
+
+describe("generateEventUrls (via createConversationFromData)", () => {
+  const baseConversation = {
+    id: "conv-123",
+    conversationType: "eventAssistant",
+    agents: [{ id: "agent-1", agentType: "eventAssistant" }],
+    channels: [] as Array<{ name: string; passcode?: string }>,
+    adapters: [],
+    platforms: [],
+  };
+
+  const mockConfig = {
+    conversationTypes: [
+      { id: "1", name: "eventAssistant" },
+      { id: "2", name: "eventAssistantPlus" },
+      { id: "3", name: "eventAssistantPlusProactive" },
+      { id: "4", name: "backChannel" },
+    ],
+    availablePlatforms: [],
+    conversationBotName: "Berkie",
+  };
+
+  let getConfigSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    // jsdom sets window.location.protocol to "about:" by default;
+    // override so generated URLs are predictable.
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { protocol: "https:", host: "example.com" },
+    });
+  });
+
+  beforeEach(() => {
+    const instance = Api.get();
+    // Reset config cache so each test starts fresh
+    (instance as any).configCache = null;
+    getConfigSpy = jest
+      .spyOn(instance, "GetConfig")
+      .mockResolvedValue(mockConfig as any);
+  });
+
+  afterEach(() => {
+    getConfigSpy.mockRestore();
+  });
+
+  it("generates a participant URL without resources param when no resources channel exists", async () => {
+    const data = { ...baseConversation, channels: [] };
+    const result = await createConversationFromData(data as any);
+    const url = result.eventUrls.participant[0]?.url;
+    expect(url).not.toContain("channel=resources");
+  });
+
+  it("appends resources channel param when a resources channel is present (eventAssistant)", async () => {
+    const data = {
+      ...baseConversation,
+      channels: [{ name: "resources", passcode: "res-secret" }],
+    };
+    const result = await createConversationFromData(data as any);
+    const url = result.eventUrls.participant[0]?.url;
+    expect(url).toContain("channel=resources,res-secret");
+  });
+
+  it("appends resources channel param for eventAssistantPlus", async () => {
+    const data = {
+      ...baseConversation,
+      conversationType: "eventAssistantPlus",
+      agents: [{ id: "agent-1", agentType: "eventAssistantPlus" }],
+      channels: [{ name: "resources", passcode: "res-plus" }],
+    };
+    const result = await createConversationFromData(data as any);
+    const url = result.eventUrls.participant[0]?.url;
+    expect(url).toContain("channel=resources,res-plus");
+  });
+
+  it("appends resources channel param for eventAssistantPlusProactive", async () => {
+    const data = {
+      ...baseConversation,
+      conversationType: "eventAssistantPlusProactive",
+      agents: [{ id: "agent-1", agentType: "eventAssistantPlusProactive" }],
+      channels: [{ name: "resources", passcode: "res-proactive" }],
+    };
+    const result = await createConversationFromData(data as any);
+    const url = result.eventUrls.participant[0]?.url;
+    expect(url).toContain("channel=resources,res-proactive");
+  });
+
+  it("includes resources param after chat param when both channels exist", async () => {
+    const data = {
+      ...baseConversation,
+      channels: [
+        { name: "chat", passcode: "chat-secret" },
+        { name: "resources", passcode: "res-secret" },
+      ],
+    };
+    const result = await createConversationFromData(data as any);
+    const url = result.eventUrls.participant[0]?.url;
+    expect(url).toContain("channel=chat,chat-secret");
+    expect(url).toContain("channel=resources,res-secret");
+    // resources appears after chat in the URL
+    expect(url.indexOf("channel=chat")).toBeLessThan(
+      url.indexOf("channel=resources"),
+    );
+  });
+
+  it("includes transcript, chat, and resources params when all three channels exist", async () => {
+    const data = {
+      ...baseConversation,
+      channels: [
+        { name: "transcript", passcode: "tx-pass" },
+        { name: "chat", passcode: "chat-pass" },
+        { name: "resources", passcode: "res-pass" },
+      ],
+    };
+    const result = await createConversationFromData(data as any);
+    const url = result.eventUrls.participant[0]?.url;
+    expect(url).toContain("channel=transcript,tx-pass");
+    expect(url).toContain("channel=chat,chat-pass");
+    expect(url).toContain("channel=resources,res-pass");
+  });
+});
+
+describe("GetChannelPasscode", () => {
+  const noopError = jest.fn();
+
+  beforeEach(() => noopError.mockClear());
+
+  it("returns the passcode when the channel is present as a string", () => {
+    const result = GetChannelPasscode("chat", { channel: "chat,chat-secret" }, noopError);
+    expect(result).toBe("chat-secret");
+  });
+
+  it("returns null when the channel is absent from a string query param", () => {
+    const result = GetChannelPasscode("resources", { channel: "chat,chat-secret" }, noopError);
+    expect(result).toBeNull();
+    expect(noopError).not.toHaveBeenCalled();
+  });
+
+  it("returns the passcode when the channel is present in an array query param", () => {
+    const result = GetChannelPasscode("resources", { channel: ["chat,chat-pass", "resources,res-pass"] }, noopError);
+    expect(result).toBe("res-pass");
+  });
+
+  it("returns null (not another channel's passcode) when channel is absent from an array query param", () => {
+    // Regression: previously returned the first channel's passcode when the target channel was missing
+    const result = GetChannelPasscode("resources", { channel: ["transcript,tx-pass", "chat,chat-pass"] }, noopError);
+    expect(result).toBeNull();
+    expect(noopError).not.toHaveBeenCalled();
+  });
+
+  it("returns null and calls setErrorMessage when query.channel is absent", () => {
+    const result = GetChannelPasscode("chat", {}, noopError);
+    expect(result).toBeNull();
+    expect(noopError).toHaveBeenCalledWith("Please provide channels.");
   });
 });

--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -4,9 +4,11 @@ import React from "react";
 import { Badge } from "@mui/material";
 import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
 import GroupIcon from "@mui/icons-material/Group";
+import MenuBookOutlined from "@mui/icons-material/MenuBookOutlined";
+import MenuBook from "@mui/icons-material/MenuBook";
 import { BotIcon } from "./BotIcon";
 import { TranscriptIcon } from "./TranscriptIcon";
-export type NavTab = "assistant" | "chat" | "transcript";
+export type NavTab = "assistant" | "chat" | "transcript" | "resources";
 
 interface NavItem {
   id: NavTab;
@@ -21,10 +23,12 @@ interface NavigationBarProps {
   onTabChange: (tab: NavTab) => void;
   unseenAssistantCount: number;
   unseenChatCount: number;
+  unseenResourcesCount?: number;
   unreadAssistantReplyCount: number;
   unreadChatReplyCount: number;
   showChat: boolean;
   showTranscript: boolean;
+  showResources?: boolean;
   botName: string;
 }
 
@@ -43,10 +47,12 @@ export function NavigationBar({
   onTabChange,
   unseenAssistantCount,
   unseenChatCount,
+  unseenResourcesCount = 0,
   unreadAssistantReplyCount,
   unreadChatReplyCount,
   showChat,
   showTranscript,
+  showResources = false,
   botName,
 }: NavigationBarProps) {
   const navItems: NavItem[] = (
@@ -72,12 +78,20 @@ export function NavigationBar({
         InactiveIcon: null,
         show: showTranscript,
       },
+      {
+        id: "resources" as NavTab,
+        label: "Resources",
+        ActiveIcon: MenuBook,
+        InactiveIcon: MenuBookOutlined,
+        show: showResources,
+      },
     ] as NavItem[]
   ).filter((item) => item.show);
 
   const getUnseenCount = (id: NavTab) => {
     if (id === "assistant") return unseenAssistantCount;
     if (id === "chat") return unseenChatCount;
+    if (id === "resources") return unseenResourcesCount;
     return 0;
   };
 

--- a/components/ResourcesPanel.tsx
+++ b/components/ResourcesPanel.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { PseudonymousMessage } from "../types.internal";
+import { parseMessageBody } from "../utils/Helpers";
+import {
+  ExpandMore,
+  ExpandLess,
+  MenuBook,
+  Person,
+  Info,
+} from "@mui/icons-material";
+
+interface ResourcesPanelProps {
+  messages: PseudonymousMessage[];
+  eventDescription?: string;
+  speakers?: Array<{ name: string; bio: string }>;
+  moderators?: Array<{ name: string; bio: string }>;
+  eventName?: string;
+  unseenReadingsCount?: number;
+  onMarkReadingsAsSeen?: () => void;
+  newReadingMessageIds?: Set<string>;
+}
+
+interface CategorySection {
+  id: string;
+  title: string;
+  icon: React.ElementType;
+  count: number;
+  defaultExpanded: boolean;
+}
+
+interface TruncatedTextProps {
+  text: string;
+  maxLength: number;
+  className?: string;
+}
+
+const TruncatedText: React.FC<TruncatedTextProps> = ({
+  text,
+  maxLength,
+  className = "",
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const needsTruncation = text.length > maxLength;
+
+  if (!needsTruncation) {
+    return <span className={className}>{text}</span>;
+  }
+
+  return (
+    <span className={className}>
+      {isExpanded ? text : `${text.slice(0, maxLength)}...`}{" "}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="text-medium-slate-blue hover:opacity-80 font-medium underline cursor-pointer"
+      >
+        {isExpanded ? "less" : "more"}
+      </button>
+    </span>
+  );
+};
+
+export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
+  messages,
+  eventDescription,
+  speakers = [],
+  moderators = [],
+  eventName,
+  unseenReadingsCount = 0,
+  onMarkReadingsAsSeen,
+  newReadingMessageIds,
+}) => {
+  // Track which categories are expanded
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
+    new Set(),
+  );
+  // Snapshot of new reading IDs captured at expand time, so highlights persist
+  // even after the parent clears newReadingMessageIds
+  const [newReadingIdsSnapshot, setNewReadingIdsSnapshot] = useState<Set<string>>(new Set());
+
+  // Extract reading recommendations from messages
+  const readings = useMemo(() => {
+    const allReadings: Array<{
+      title: string;
+      url?: string;
+      authors: string[];
+      year: number;
+      abstract?: string;
+      relevanceReason?: string;
+      messageId: string;
+    }> = [];
+
+    messages.forEach((msg) => {
+      const parsed = parseMessageBody(msg.body);
+      if (parsed.type === "reading" && Array.isArray(parsed.content)) {
+        allReadings.push(
+          ...parsed.content.map((r) => ({ ...r, messageId: msg.id! })),
+        );
+      }
+    });
+
+    return allReadings;
+  }, [messages]);
+
+  const categories: CategorySection[] = [
+    {
+      id: "speakers",
+      title: "Speakers",
+      icon: Person,
+      count: 0, // Don't show badge for speakers (static content)
+      defaultExpanded: false,
+    },
+    {
+      id: "readings",
+      title: "Readings & References",
+      icon: MenuBook,
+      count: unseenReadingsCount,
+      defaultExpanded: false,
+    },
+  ];
+
+  const toggleCategory = (categoryId: string) => {
+    setExpandedCategories((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(categoryId)) {
+        newSet.delete(categoryId);
+        if (categoryId === "readings") setNewReadingIdsSnapshot(new Set());
+      } else {
+        newSet.add(categoryId);
+        // Snapshot current new IDs before clearing, so highlights render correctly
+        if (categoryId === "readings") {
+          setNewReadingIdsSnapshot(new Set(newReadingMessageIds));
+          if (onMarkReadingsAsSeen) onMarkReadingsAsSeen();
+        }
+      }
+      return newSet;
+    });
+  };
+
+  const CategoryHeader: React.FC<{
+    category: CategorySection;
+    isExpanded: boolean;
+  }> = ({ category, isExpanded }) => {
+    const Icon = category.icon;
+    return (
+      <button
+        onClick={() => toggleCategory(category.id)}
+        aria-expanded={isExpanded}
+        className="w-full flex items-center justify-between px-4 py-3 bg-white border-b border-gray-200 hover:bg-gray-50 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <Icon sx={{ fontSize: 20, color: "#4A0979" }} aria-hidden="true" />
+          <span className="font-semibold text-gray-900 text-sm">
+            {category.title}
+          </span>
+          {category.count > 0 && (
+            <span aria-hidden="true" className="text-xs bg-purple-100 text-purple-700 px-2 py-0.5 rounded-full font-medium">
+              {category.count}
+            </span>
+          )}
+        </div>
+        {isExpanded ? (
+          <ExpandLess sx={{ fontSize: 20, color: "#666" }} aria-hidden="true" />
+        ) : (
+          <ExpandMore sx={{ fontSize: 20, color: "#666" }} aria-hidden="true" />
+        )}
+      </button>
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden bg-gray-50">
+      {/* Event Description Header */}
+      <div className="flex-shrink-0 bg-gradient-to-r from-purple-50 to-indigo-50 border-b border-purple-200 px-6 py-4">
+        <div className="flex items-start gap-3">
+          <Info sx={{ fontSize: 24, color: "#4A0979", marginTop: "2px" }} />
+          <div>
+            <h1 className="text-lg font-bold text-gray-900 mb-1">
+              {eventName || "Event Resources"}
+            </h1>
+            {eventDescription && (
+              <p className="text-sm text-gray-700 leading-relaxed">
+                <TruncatedText
+                  text={eventDescription}
+                  maxLength={500}
+                  className="text-sm text-gray-700 leading-relaxed"
+                />
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Scrollable Categories */}
+      <div className="flex-1 overflow-y-auto">
+        {/* Speakers */}
+        <div className="mb-2">
+          <CategoryHeader
+            category={categories[0]}
+            isExpanded={expandedCategories.has("speakers")}
+          />
+          {expandedCategories.has("speakers") && (
+            <div className="bg-white px-6 py-4 border-b border-gray-200">
+              <div className="space-y-4">
+                {moderators.length > 0 && (
+                  <div>
+                    <h4 className="text-xs font-bold text-gray-500 uppercase tracking-wide mb-3">
+                      Moderators
+                    </h4>
+                    <div className="space-y-3">
+                      {moderators.map((mod, idx) => (
+                        <div key={idx} className="flex items-start gap-3">
+                          <div className="bg-gradient-to-br from-blue-100 to-blue-200 rounded-full w-10 h-10 flex items-center justify-center flex-shrink-0">
+                            <Person sx={{ fontSize: 20, color: "#1e40af" }} />
+                          </div>
+                          <div>
+                            <h5 className="text-sm font-semibold text-gray-900">
+                              {mod.name}
+                            </h5>
+                            <p className="text-xs text-gray-600 leading-relaxed mt-1">
+                              <TruncatedText
+                                text={mod.bio}
+                                maxLength={300}
+                                className="text-xs text-gray-600 leading-relaxed"
+                              />
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {speakers.length > 0 && (
+                  <div>
+                    <h4 className="text-xs font-bold text-gray-500 uppercase tracking-wide mb-3">
+                      Speakers
+                    </h4>
+                    <div className="space-y-3">
+                      {speakers.map((speaker, idx) => (
+                        <div key={idx} className="flex items-start gap-3">
+                          <div className="bg-gradient-to-br from-purple-100 to-purple-200 rounded-full w-10 h-10 flex items-center justify-center flex-shrink-0">
+                            <Person sx={{ fontSize: 20, color: "#4A0979" }} />
+                          </div>
+                          <div>
+                            <h5 className="text-sm font-semibold text-gray-900">
+                              {speaker.name}
+                            </h5>
+                            <p className="text-xs text-gray-600 leading-relaxed mt-1">
+                              <TruncatedText
+                                text={speaker.bio}
+                                maxLength={300}
+                                className="text-xs text-gray-600 leading-relaxed"
+                              />
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Readings & References */}
+        <div className="mb-2">
+          <CategoryHeader
+            category={categories[1]}
+            isExpanded={expandedCategories.has("readings")}
+          />
+          {expandedCategories.has("readings") && (
+            <div className="bg-white px-6 py-4 border-b border-gray-200">
+              <p className="text-xs text-gray-400 mb-3">
+                References sourced from{" "}
+                <a
+                  href="https://www.semanticscholar.org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-gray-600"
+                >
+                  Semantic Scholar
+                </a>
+                .
+              </p>
+              <ul className="space-y-4 list-none">
+                {readings.length === 0 ? (
+                  <li className="text-sm text-gray-500 italic">
+                    No reading recommendations available yet.
+                  </li>
+                ) : (
+                  readings.map((reading, idx) => {
+                    const isNew = newReadingIdsSnapshot.has(reading.messageId);
+                    return (
+                      <li
+                        key={idx}
+                        className={`border-l-4 pl-4 py-3 rounded-r ${
+                          isNew
+                            ? "border-amber-400 bg-amber-50"
+                            : "border-indigo-400 bg-indigo-50"
+                        }`}
+                      >
+                        <div aria-hidden="true" className="flex items-center gap-2 mb-2">
+                          <span className="inline-block text-xs font-semibold text-purple-700 bg-purple-100 px-2 py-0.5 rounded-full">
+                            AI Pick
+                          </span>
+                          {isNew && (
+                            <span className="inline-block text-xs font-semibold text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">
+                              New
+                            </span>
+                          )}
+                        </div>
+                        <h3
+                          className={`text-sm font-semibold mb-1 ${isNew ? "text-amber-900" : "text-indigo-900"}`}
+                        >
+                          {reading.url ? (
+                            <a
+                              href={reading.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="hover:underline"
+                            >
+                              {reading.title}
+                            </a>
+                          ) : (
+                            <span tabIndex={0}>{reading.title}</span>
+                          )}
+                        </h3>
+                        <p tabIndex={0} className="text-xs text-gray-600 mb-2">
+                          <span className="sr-only">Authors and year: </span>
+                          {reading.authors.join(", ")} ({reading.year})
+                        </p>
+                        {(reading.relevanceReason || reading.abstract) && (
+                          <p tabIndex={0} className="text-xs text-gray-700 leading-relaxed mb-2">
+                            <span className="sr-only">Relevance: </span>
+                            {reading.relevanceReason || reading.abstract}
+                          </p>
+                        )}
+                      </li>
+                    );
+                  })
+                )}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/ResourcesPanel.tsx
+++ b/components/ResourcesPanel.tsx
@@ -272,7 +272,7 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
           />
           {expandedCategories.has("readings") && (
             <div className="bg-white px-6 py-4 border-b border-gray-200">
-              <p className="text-xs text-gray-400 mb-3">
+              <p className="text-xs text-gray-600 mb-3">
                 References sourced from{" "}
                 <a
                   href="https://www.semanticscholar.org"
@@ -306,7 +306,7 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
                             AI Pick
                           </span>
                           {isNew && (
-                            <span className="inline-block text-xs font-semibold text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">
+                            <span className="inline-block text-xs font-semibold text-amber-800 bg-amber-100 px-2 py-0.5 rounded-full">
                               New
                             </span>
                           )}

--- a/components/ResourcesPanel.tsx
+++ b/components/ResourcesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { PseudonymousMessage } from "../types.internal";
 import { parseMessageBody } from "../utils/Helpers";
 import {
@@ -77,7 +77,19 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
   );
   // Snapshot of new reading IDs captured at expand time, so highlights persist
   // even after the parent clears newReadingMessageIds
-  const [newReadingIdsSnapshot, setNewReadingIdsSnapshot] = useState<Set<string>>(new Set());
+  const [newReadingIdsSnapshot, setNewReadingIdsSnapshot] = useState<
+    Set<string>
+  >(new Set());
+
+  // When new readings arrive while the section is already expanded, merge them into the snapshot
+  useEffect(() => {
+    if (!expandedCategories.has("readings") || !newReadingMessageIds) return;
+    setNewReadingIdsSnapshot((prev) => {
+      const hasNew = [...newReadingMessageIds].some((id) => !prev.has(id));
+      if (!hasNew) return prev;
+      return new Set([...prev, ...newReadingMessageIds]);
+    });
+  }, [newReadingMessageIds, expandedCategories]);
 
   // Extract reading recommendations from messages
   const readings = useMemo(() => {
@@ -125,17 +137,21 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
       const newSet = new Set(prev);
       if (newSet.has(categoryId)) {
         newSet.delete(categoryId);
-        if (categoryId === "readings") setNewReadingIdsSnapshot(new Set());
       } else {
         newSet.add(categoryId);
-        // Snapshot current new IDs before clearing, so highlights render correctly
-        if (categoryId === "readings") {
-          setNewReadingIdsSnapshot(new Set(newReadingMessageIds));
-          if (onMarkReadingsAsSeen) onMarkReadingsAsSeen();
-        }
       }
       return newSet;
     });
+    if (categoryId === "readings") {
+      if (expandedCategories.has(categoryId)) {
+        // Mark as seen on collapse so re-expanding doesn't re-show highlights
+        setNewReadingIdsSnapshot(new Set());
+        if (onMarkReadingsAsSeen) onMarkReadingsAsSeen();
+      } else {
+        // Snapshot current new IDs before clearing, so highlights render correctly
+        setNewReadingIdsSnapshot(new Set(newReadingMessageIds));
+      }
+    }
   };
 
   const CategoryHeader: React.FC<{
@@ -155,7 +171,10 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
             {category.title}
           </span>
           {category.count > 0 && (
-            <span aria-hidden="true" className="text-xs bg-purple-100 text-purple-700 px-2 py-0.5 rounded-full font-medium">
+            <span
+              aria-hidden="true"
+              className="text-xs bg-purple-100 text-purple-700 px-2 py-0.5 rounded-full font-medium"
+            >
               {category.count}
             </span>
           )}
@@ -290,18 +309,21 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
                     No reading recommendations available yet.
                   </li>
                 ) : (
-                  readings.map((reading, idx) => {
+                  readings.map((reading) => {
                     const isNew = newReadingIdsSnapshot.has(reading.messageId);
                     return (
                       <li
-                        key={idx}
+                        key={reading.messageId}
                         className={`border-l-4 pl-4 py-3 rounded-r ${
                           isNew
                             ? "border-amber-400 bg-amber-50"
                             : "border-indigo-400 bg-indigo-50"
                         }`}
                       >
-                        <div aria-hidden="true" className="flex items-center gap-2 mb-2">
+                        <div
+                          aria-hidden="true"
+                          className="flex items-center gap-2 mb-2"
+                        >
                           <span className="inline-block text-xs font-semibold text-purple-700 bg-purple-100 px-2 py-0.5 rounded-full">
                             AI Pick
                           </span>
@@ -332,7 +354,10 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
                           {reading.authors.join(", ")} ({reading.year})
                         </p>
                         {(reading.relevanceReason || reading.abstract) && (
-                          <p tabIndex={0} className="text-xs text-gray-700 leading-relaxed mb-2">
+                          <p
+                            tabIndex={0}
+                            className="text-xs text-gray-700 leading-relaxed mb-2"
+                          >
                             <span className="sr-only">Relevance: </span>
                             {reading.relevanceReason || reading.abstract}
                           </p>

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -100,6 +100,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [unseenAssistantCount, setUnseenAssistantCount] = useState<number>(0);
   const [unseenChatCount, setUnseenChatCount] = useState<number>(0);
   const [unseenResourcesCount, setUnseenResourcesCount] = useState<number>(0);
+  const [resourcesNavBadgeDismissed, setResourcesNavBadgeDismissed] = useState(false);
   const [unreadAssistantReplyCount, setUnreadAssistantReplyCount] = useState<number>(0);
   const [unreadChatReplyCount, setUnreadChatReplyCount] = useState<number>(0);
   // Track which resource message IDs contain new (unseen) readings for highlighting
@@ -244,14 +245,17 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         if (data.id) {
           setNewReadingMessageIds((prev) => new Set([...prev, data.id!]));
         }
-        // Increment counter if NOT viewing resources tab
+        // Always increment counter so the in-panel badge shows when already on the resources tab
+        const parsed = parseMessageBody(data.body);
+        const readingCount =
+          parsed.type === "reading" && Array.isArray(parsed.content)
+            ? parsed.content.length
+            : 1;
+        setUnseenResourcesCount((prev) => prev + readingCount);
+        // Only clear the nav badge dismissal when NOT on the resources tab
+        // (nav badge is separately suppressed by resourcesNavBadgeDismissed while on the tab)
         if (activeTabRef.current !== "resources") {
-          const parsed = parseMessageBody(data.body);
-          const readingCount =
-            parsed.type === "reading" && Array.isArray(parsed.content)
-              ? parsed.content.length
-              : 1;
-          setUnseenResourcesCount((prev) => prev + readingCount);
+          setResourcesNavBadgeDismissed(false);
         }
       } else if (!data.channels || !data.channels.includes("transcript")) {
         setAssistantMessages((prev) => [...prev, data]);
@@ -936,10 +940,13 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     } else if (tab === "chat") {
       setUnseenChatCount(0);
       // Note: unreadReplyCount is managed by GroupChatPanel visibility logic
+    } else if (tab === "resources") {
+      setResourcesNavBadgeDismissed(true);
     }
-    // Clear reading highlights when leaving the resources tab
+    // Clear reading state when leaving the resources tab
     if (activeTab === "resources" && tab !== "resources") {
       setNewReadingMessageIds(new Set());
+      setUnseenResourcesCount(0);
     }
     // Track tab switch analytics (transcript treated as a nav destination)
     trackConversationEvent(
@@ -992,7 +999,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
             onTabChange={handleTabChange}
             unseenAssistantCount={unseenAssistantCount}
             unseenChatCount={unseenChatCount}
-            unseenResourcesCount={unseenResourcesCount}
+            unseenResourcesCount={resourcesNavBadgeDismissed ? 0 : unseenResourcesCount}
             unreadAssistantReplyCount={unreadAssistantReplyCount}
             unreadChatReplyCount={unreadChatReplyCount}
             showChat={!!chatPasscode}

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 
 import { AssistantChatPanel } from "../components/AssistantChatPanel";
 import { GroupChatPanel } from "../components/GroupChatPanel";
+import { ResourcesPanel } from "../components/ResourcesPanel";
 import { SlashCommand } from "../components/enhancers/slashCommandEnhancer";
 import {
   Api,
@@ -22,6 +23,7 @@ import {
   CheckAuthHeader,
   createConversationFromData,
   resolveConversationBotName,
+  parseMessageBody,
 } from "../utils/Helpers";
 import { useAnalytics } from "../hooks/useAnalytics";
 import { AuthType } from "../types.internal";
@@ -97,8 +99,11 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [activeTab, setActiveTab] = useState<NavTab>("chat");
   const [unseenAssistantCount, setUnseenAssistantCount] = useState<number>(0);
   const [unseenChatCount, setUnseenChatCount] = useState<number>(0);
+  const [unseenResourcesCount, setUnseenResourcesCount] = useState<number>(0);
   const [unreadAssistantReplyCount, setUnreadAssistantReplyCount] = useState<number>(0);
   const [unreadChatReplyCount, setUnreadChatReplyCount] = useState<number>(0);
+  // Track which resource message IDs contain new (unseen) readings for highlighting
+  const [newReadingMessageIds, setNewReadingMessageIds] = useState<Set<string>>(new Set());
 
   // Track previous reply counts for chat messages (persists across tab switches)
   const [chatPreviousReplyCounts, setChatPreviousReplyCounts] = useState<
@@ -112,6 +117,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     PseudonymousMessage[]
   >([]);
   const [chatMessages, setChatMessages] = useState<PseudonymousMessage[]>([]);
+  const [resourcesMessages, setResourcesMessages] = useState<PseudonymousMessage[]>([]);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [jargonFilterAgentId, setJargonFilterAgentId] = useState<string | null>(
     null,
@@ -128,7 +134,11 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     useState<ControlledInputConfig | null>(null);
   const [transcriptPasscode, setTranscriptPasscode] = useState<string>("");
   const [chatPasscode, setChatPasscode] = useState<string>("");
+  const [resourcesPasscode, setResourcesPasscode] = useState<string>("");
   const [eventName, setEventName] = useState<string>("");
+  const [eventDescription, setEventDescription] = useState<string>("");
+  const [speakers, setSpeakers] = useState<Array<{ name: string; bio: string }>>([]);
+  const [moderators, setModerators] = useState<Array<{ name: string; bio: string }>>([]);
   const [botName, setBotName] = useState<string>("Berkie");
   const [assistantInputValue, setAssistantInputValue] = useState<string>("");
   const [chatInputValue, setChatInputValue] = useState<string>("");
@@ -228,6 +238,21 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         if (activeTabRef.current !== "chat") {
           setUnseenChatCount((prev) => prev + 1);
         }
+      } else if (data.channels && data.channels.includes("resources")) {
+        setResourcesMessages((prev) => [...prev, data]);
+        // Track message ID for highlight on expand
+        if (data.id) {
+          setNewReadingMessageIds((prev) => new Set([...prev, data.id!]));
+        }
+        // Increment counter if NOT viewing resources tab
+        if (activeTabRef.current !== "resources") {
+          const parsed = parseMessageBody(data.body);
+          const readingCount =
+            parsed.type === "reading" && Array.isArray(parsed.content)
+              ? parsed.content.length
+              : 1;
+          setUnseenResourcesCount((prev) => prev + readingCount);
+        }
       } else if (!data.channels || !data.channels.includes("transcript")) {
         setAssistantMessages((prev) => [...prev, data]);
         // Increment counter if NOT viewing assistant tab
@@ -297,11 +322,20 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         setConversationType(conversation.type.name);
         if (conversation.name) setEventName(conversation.name);
 
-        // Extract feedback frequency from conversation properties
+        // Extract event metadata from conversation
         const frequency =
           (conversation?.properties?.feedbackFrequency as number) || 1;
-
         setFeedbackFrequency(frequency);
+
+        if (conversation?.description) {
+          setEventDescription(conversation.description as string);
+        }
+        if (conversation?.presenters) {
+          setSpeakers(conversation.presenters as Array<{ name: string; bio: string }>);
+        }
+        if (conversation?.moderators) {
+          setModerators(conversation.moderators as Array<{ name: string; bio: string }>);
+        }
 
         // Override botName from the first agent's agentConfig if available,
         // falling back to config.conversationBotName
@@ -329,6 +363,16 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
 
           if (chatPasscodeParam) {
             setChatPasscode(chatPasscodeParam);
+          }
+
+          const resourcesPasscodeParam = GetChannelPasscode(
+            "resources",
+            router.query,
+            setLocalError,
+          );
+
+          if (resourcesPasscodeParam) {
+            setResourcesPasscode(resourcesPasscodeParam);
           }
         }
 
@@ -397,6 +441,13 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         direct: false,
       });
     }
+    if (resourcesPasscode) {
+      channels.push({
+        name: "resources",
+        passcode: resourcesPasscode,
+        direct: false,
+      });
+    }
 
     const joinConversation = () => {
       console.log("Joining conversation");
@@ -431,6 +482,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     userId,
     userPreferences,
     chatPasscode,
+    resourcesPasscode,
     router.query.conversationId,
   ]);
 
@@ -578,6 +630,28 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     fetchInitialMessages();
   }, [chatPasscode, router.query.conversationId]);
 
+  // Load initial resources messages when resourcesPasscode becomes available
+  useEffect(() => {
+    if (!resourcesPasscode || !router.query.conversationId) return;
+
+    const fetchInitialMessages = async () => {
+      try {
+        const resourcesMessages = await RetrieveData(
+          `messages/${router.query.conversationId}?channel=resources,${resourcesPasscode}`,
+          Api.get().getAccessToken(),
+        );
+
+        if (Array.isArray(resourcesMessages)) {
+          setResourcesMessages(resourcesMessages);
+        }
+      } catch (error) {
+        console.error("Error fetching initial resources messages:", error);
+      }
+    };
+
+    fetchInitialMessages();
+  }, [resourcesPasscode, router.query.conversationId]);
+
   // Check if user has existing preferences
   useEffect(() => {
     if (!userId) return;
@@ -642,8 +716,19 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         .catch((err) => console.error("Error re-fetching chat messages:", err));
     }
 
+    if (resourcesPasscode) {
+      RetrieveData(
+        `messages/${router.query.conversationId}?channel=resources,${resourcesPasscode}`,
+        Api.get().getAccessToken(),
+      )
+        .then((msgs) => {
+          if (Array.isArray(msgs)) setResourcesMessages(msgs);
+        })
+        .catch((err) => console.error("Error re-fetching resources messages:", err));
+    }
+
     fetchAllAssistantMessages();
-  }, [lastReconnectTime, router.query.conversationId, chatPasscode, fetchAllAssistantMessages]);
+  }, [lastReconnectTime, router.query.conversationId, chatPasscode, resourcesPasscode, fetchAllAssistantMessages]);
 
   async function sendMessage(
     message: string,
@@ -852,6 +937,10 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
       setUnseenChatCount(0);
       // Note: unreadReplyCount is managed by GroupChatPanel visibility logic
     }
+    // Clear reading highlights when leaving the resources tab
+    if (activeTab === "resources" && tab !== "resources") {
+      setNewReadingMessageIds(new Set());
+    }
     // Track tab switch analytics (transcript treated as a nav destination)
     trackConversationEvent(
       router.query.conversationId as string,
@@ -859,6 +948,11 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
       "tab_switched",
       tab,
     );
+  };
+
+  const handleMarkReadingsAsSeen = () => {
+    setUnseenResourcesCount(0);
+    setNewReadingMessageIds(new Set());
   };
 
   // Create feedback config for assistant messages
@@ -898,10 +992,12 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
             onTabChange={handleTabChange}
             unseenAssistantCount={unseenAssistantCount}
             unseenChatCount={unseenChatCount}
+            unseenResourcesCount={unseenResourcesCount}
             unreadAssistantReplyCount={unreadAssistantReplyCount}
             unreadChatReplyCount={unreadChatReplyCount}
             showChat={!!chatPasscode}
             showTranscript={!!transcriptPasscode}
+            showResources={true}
             botName={botName}
           />
 
@@ -921,7 +1017,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
               </div>
             ) : (
               <>
-                {/* Chat / Assistant panel */}
+                {/* Chat / Assistant / Resources panel */}
                 <div className="flex-1 flex flex-col relative overflow-hidden">
                   {isConnected ? (
                     activeTab === "chat" ? (
@@ -950,6 +1046,17 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
                             return newSet;
                           });
                         }}
+                      />
+                    ) : activeTab === "resources" ? (
+                      <ResourcesPanel
+                        messages={resourcesMessages}
+                        eventDescription={eventDescription}
+                        speakers={speakers}
+                        moderators={moderators}
+                        eventName={eventName}
+                        unseenReadingsCount={unseenResourcesCount}
+                        onMarkReadingsAsSeen={handleMarkReadingsAsSeen}
+                        newReadingMessageIds={newReadingMessageIds}
                       />
                     ) : (
                       <AssistantChatPanel

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -18,6 +18,7 @@ import TokenManagerDefault from "./TokenManager";
  * @property {string} [message] - Optional message ID reference
  * @property {MediaItem[]} [media] - Optional array of media items (images, audio, video)
  * @property {string} [sourceMessage] - Optional ID of the message this response is based on (for multimodal responses)
+ * @property {any} [content] - Optional structured content (objects, arrays, etc.)
  */
 export interface ParsedMessageBody {
   text: string;
@@ -25,6 +26,7 @@ export interface ParsedMessageBody {
   message?: string;
   media?: MediaItem[];
   sourceMessage?: string;
+  content?: any;
 }
 
 /**
@@ -42,6 +44,7 @@ export const parseMessageBody = (body: string | object): ParsedMessageBody => {
       message: obj.message?.toString(),
       media: Array.isArray(obj.media) ? obj.media : undefined,
       sourceMessage: obj.sourceMessage?.toString(),
+      content: obj.content,
     };
   }
 
@@ -195,11 +198,12 @@ export const GetChannelPasscode = (
       }
     });
 
-    // Get the passcode from channel string
-    passcodeParam = query.channel[channelIndex].split(",")[1];
   }
 
   if (hasChannel) {
+    if (typeof query.channel !== "string") {
+      passcodeParam = query.channel[channelIndex].split(",")[1];
+    }
     if (!passcodeParam) {
       setErrorMessage(`Please provide a ${channel} passcode.`);
       return null;
@@ -337,6 +341,11 @@ function generateEventUrls(
   )?.passcode;
   const hasChat = Boolean(chatPasscode);
 
+  const resourcesPasscode = conversationData.channels.find(
+    (channel) => channel.name === "resources",
+  )?.passcode;
+  const hasResources = Boolean(resourcesPasscode);
+
   const modPasscode = conversationData.channels.find(
     (channel) => channel.name === "moderator",
   )?.passcode;
@@ -371,7 +380,9 @@ function generateEventUrls(
       label: botName,
       url: `${urlPrefix}/assistant/?conversationId=${conversationData.id}${
         hasTranscript ? `&channel=transcript,${transcriptPasscode}` : ""
-      }${hasChat ? `&channel=chat,${chatPasscode}` : ""}`,
+      }${hasChat ? `&channel=chat,${chatPasscode}` : ""}${
+        hasResources ? `&channel=resources,${resourcesPasscode}` : ""
+      }`,
     };
     participant.push(eventAssistantUrl);
   } else if (
@@ -387,7 +398,9 @@ function generateEventUrls(
       label,
       url: `${urlPrefix}/assistant/?conversationId=${conversationData.id}${
         hasTranscript ? `&channel=transcript,${transcriptPasscode}` : ""
-      }${hasChat ? `&channel=chat,${chatPasscode}` : ""}`,
+      }${hasChat ? `&channel=chat,${chatPasscode}` : ""}${
+        hasResources ? `&channel=resources,${resourcesPasscode}` : ""
+      }`,
     };
     participant.push(eventAssistantPlusUrl);
     if (modPasscode) {


### PR DESCRIPTION
## What is in this PR?

- Adds a new Resources tab to the assistant page
   - Resources should feel more like a handout packet that grows during the event, while Berkie is your private tutor who's always ready to help.
   - Resources can all be taken away post-event (perhaps with a quick 'email this to me' button if we don't want to require user registration. There are ton of tickets open for follow-up work on the Resources tab)
- Populates Event and Speaker/Moderator info on Resources tab
- Dynamically adds reading recommendations (messages on 'resources' channel that have body with type: reading, content: [array of recommendation objects]) to a Reading & References section with an 'AI Pick' banner
- Adds dot to Notification tab when new recommendations come in (current default is every 15 minutes)
- Shows the number of unread reading on the Reading & References header and highlights the new recommendations when you expand

## Changes in the codebase
See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

- [x] Test in conjunction with BE PR https://github.com/berkmancenter/llm_engine/pull/75
- [x] Create an eventAssistantPlus conversation
        - [ ] Provide an event description
        - [ ] Ensure Reading Recommendations feature is present and enabled by default, with default value of 2 recommendations per interval
        - [ ] Add a speaker and moderator
- [x] Navigate to assistant page and ensure event and speaker info shown on Resources tab
- [ ] Play a longish (at least slightly more than 15 minutes) academic talk. Stay on a different tab and ensure notification dot show on Resources tab when new ones come in
- [ ] Ensure the expected number of readings are present and the number is shown on the Readings & Reference header
- [ ] Verify new readings are highlighted in amber color on expansion
- [ ] Collapse and verify 'new' color is no longer there
- [ ] Follow URLs to readings and make sure legit. Ensure reason for recommendation seems relevant to the talk
- [ ] If time to do more than one cycle, stay on the Resources tab when new recommendations come in and make sure no dot shows on Resources tab

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
