### PR TITLE
fix: Message rendering issues

### DIFF
--- a/components/ThreadedMessage.tsx
+++ b/components/ThreadedMessage.tsx
@@ -165,20 +165,7 @@ export const ThreadedMessage: FC<ThreadedMessageProps> = ({
 
       {/* Message with avatar - always left-aligned */}
       <div
-        className={`flex gap-1.5 mb-1 flex-row transition-colors ${isThreadOpen ? "bg-blue-50 border-l-4 border-blue-400 pl-2 py-2 -ml-2 rounded-r-lg" : ""}`}
-        style={{
-          backgroundColor:
-            showReplyButton && !isThreadOpen ? "white" : undefined,
-          marginLeft: showReplyButton && !isThreadOpen ? "-8px" : undefined,
-          marginRight: showReplyButton && !isThreadOpen ? "-8px" : undefined,
-          marginTop: showReplyButton && !isThreadOpen ? "-4px" : undefined,
-          marginBottom: showReplyButton && !isThreadOpen ? "-16px" : undefined,
-          paddingLeft: showReplyButton && !isThreadOpen ? "8px" : undefined,
-          paddingRight: showReplyButton && !isThreadOpen ? "8px" : undefined,
-          paddingTop: showReplyButton && !isThreadOpen ? "4px" : undefined,
-          paddingBottom: showReplyButton && !isThreadOpen ? "16px" : undefined,
-          borderRadius: showReplyButton && !isThreadOpen ? "8px" : undefined,
-        }}
+        className={`flex flex-row gap-1.5 p-2 rounded-[.5rem] transition-all ${isThreadOpen ? "bg-blue-50 border-l-4 border-blue-400 pl-2 py-2 -ml-2 rounded-r-lg" : `${showReplyButton && "bg-white"}`}`}
       >
         {/* Avatar */}
         {renderAvatar(message)}
@@ -195,49 +182,45 @@ export const ThreadedMessage: FC<ThreadedMessageProps> = ({
 
           {/* Message bubble wrapper with hover state - extended to include button area */}
           <div
-            className="relative"
+            className="relative w-full lg:w-[calc(85% + 24px)]"
             onTouchStart={handleTouchStart}
             onTouchEnd={handleTouchEnd}
             onTouchMove={handleTouchMove}
             onMouseEnter={() => setShowReplyButton(true)}
             onMouseLeave={() => setShowReplyButton(false)}
-            style={{ width: "calc(85% + 24px)" }}
           >
             {/* Message bubble - renderMessageContent provides the complete styled bubble */}
-            <div className="relative" style={{ width: "calc(100% - 24px)" }}>
+            <div className="relative flex flex-row gap-1 lg:gap-4">
               {renderMessageContent(message)}
-            </div>
 
-            {/* Reply button pill - reply icon in top right */}
-            {showReplyButton && (
-              <IconButton
-                onClick={handleReplyClick}
-                onMouseEnter={() => setShowReplyButton(true)}
-                size="small"
-                aria-label={`Reply to ${displayName}`}
-                sx={{
-                  position: "absolute",
-                  top: -4,
-                  right: 32,
-                  width: 32,
-                  height: 32,
-                  backgroundColor: "white",
-                  border: "1.5px solid #d1d5db",
-                  boxShadow: "0 4px 6px rgba(0,0,0,0.15)",
-                  transition: "all 0.2s ease",
-                  "&:hover": {
-                    backgroundColor: "#4A0979",
-                    borderColor: "#4A0979",
-                    boxShadow: "0 6px 12px rgba(74,9,121,0.3)",
-                    "& svg": {
-                      color: "white",
+              {/* Reply button pill - reply icon in top right */}
+              {showReplyButton && (
+                <IconButton
+                  onClick={handleReplyClick}
+                  onMouseEnter={() => setShowReplyButton(true)}
+                  size="small"
+                  aria-label={`Reply to ${displayName}`}
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    backgroundColor: "white",
+                    border: "1.5px solid #d1d5db",
+                    boxShadow: "0 4px 6px rgba(0,0,0,0.15)",
+                    transition: "all 0.2s ease",
+                    "&:hover": {
+                      backgroundColor: "#4A0979",
+                      borderColor: "#4A0979",
+                      boxShadow: "0 6px 12px rgba(74,9,121,0.3)",
+                      "& svg": {
+                        color: "white",
+                      },
                     },
-                  },
-                }}
-              >
-                <Reply sx={{ fontSize: 18, color: "#6b7280" }} />
-              </IconButton>
-            )}
+                  }}
+                >
+                  <Reply sx={{ fontSize: 18, color: "#6b7280" }} />
+                </IconButton>
+              )}
+            </div>
           </div>
 
           {/* First reply preview - always left-aligned */}


### PR DESCRIPTION
## What is in this PR?
On the current production build, when a user hovers over or taps on a message in a thread, the layout shifts to accommodate the reply button ([issue](https://github.com/orgs/berkmancenter/projects/6/views/1?pane=issue&itemId=174170714&issue=berkmancenter%7Cllm_engine_archive%7C546)). This resolves that issue and simplifies that part of the layout overall.

## Changes in the codebase
All in `./components/ThreadedMessage.tsx`:
- Remove unneeded, superfluous `style` attributes with conditional values such as `marginLeft`
- Move reply button to be sibling of message bubble content, so that various `style` attributes are no longer needed to position it in the flow (use `flex` row instead).

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR
- [ ] After applying this fix, note that on all viewport sizes, the layout no longer shifts when a reply button appears to the right of a message.