### PR TITLE
feat: add In reply to banner with voice questions to agent responses in group chat

### DIFF
--- a/__tests__/components/GroupChatPanel.test.tsx
+++ b/__tests__/components/GroupChatPanel.test.tsx
@@ -2088,6 +2088,82 @@ describe("GroupChatPanel", () => {
     });
   });
 
+  describe("Voice reply banner", () => {
+    const agentMessage = (body: Record<string, unknown>) => ({
+      id: "1",
+      pseudonym: "Event Assistant",
+      createdAt: "2025-10-17T12:00:00Z",
+      body,
+      channels: ["chat"],
+      conversation: "conv-1",
+      pseudonymId: "ea-1",
+      fromAgent: true,
+      pause: false,
+      visible: true,
+      upVotes: [],
+      downVotes: [],
+    });
+
+    it("shows voice banner with 🔊 prefix for bot message with source=voice", () => {
+      render(
+        <GroupChatPanel
+          {...baseProps}
+          messages={[
+            agentMessage({
+              text: "Here is my answer",
+              source: "voice",
+              sourceMessage: "What is the agenda?",
+            }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByText(/In reply to:/)).toBeInTheDocument();
+      expect(screen.getByText(/🔊/)).toBeInTheDocument();
+      expect(screen.getByText(/What is the agenda\?/)).toBeInTheDocument();
+    });
+
+    it("does not show banner when source is not voice", () => {
+      render(
+        <GroupChatPanel
+          {...baseProps}
+          messages={[agentMessage({ text: "Just a normal response" })]}
+        />,
+      );
+
+      expect(screen.queryByText(/In reply to:/)).not.toBeInTheDocument();
+    });
+
+    it("does not show banner when sourceMessage is missing", () => {
+      render(
+        <GroupChatPanel
+          {...baseProps}
+          messages={[agentMessage({ text: "Answer", source: "voice" })]}
+        />,
+      );
+
+      expect(screen.queryByText(/In reply to:/)).not.toBeInTheDocument();
+    });
+
+    it("truncates sourceMessage longer than 60 characters", () => {
+      const longQuestion = "a".repeat(80);
+      render(
+        <GroupChatPanel
+          {...baseProps}
+          messages={[
+            agentMessage({
+              text: "Answer",
+              source: "voice",
+              sourceMessage: longQuestion,
+            }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByText(new RegExp("a{60}\\.\\.\\."))). toBeInTheDocument();
+    });
+  });
+
   describe("Thinking Bot Icon", () => {
     it("shows thinking bot icon when waiting for non-threaded response", () => {
       const messages = [

--- a/components/GroupChatPanel.tsx
+++ b/components/GroupChatPanel.tsx
@@ -189,16 +189,32 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
     }
 
     // Assistant messages
+    const isVoiceReply = parsed.source === "voice";
+    const sourceContextText = parsed.sourceMessage
+      ? parsed.sourceMessage.length > 60
+        ? parsed.sourceMessage.substring(0, 60) + "..."
+        : parsed.sourceMessage
+      : null;
+
     return (
-      <div
-        className="rounded-2xl px-2 py-1 text-gray-800 self-start"
-        style={{
-          backgroundColor: isHovered ? "white" : style.bubbleBg,
-          width: "85%",
-          border: "1px solid rgba(0, 0, 0, 0.1)",
-        }}
-      >
-        {renderAssistantMessage(parsed.text)}
+      <div style={{ width: "85%" }}>
+        {sourceContextText && (
+          <div className="text-xs text-gray-500 mb-1.5 pl-2 py-1 border-l-2 border-gray-300 bg-gray-50 rounded">
+            <span className="font-medium">
+              {isVoiceReply ? "🔊 " : ""}In reply to:{" "}
+            </span>
+            {sourceContextText}
+          </div>
+        )}
+        <div
+          className="rounded-2xl px-2 py-1 text-gray-800 self-start"
+          style={{
+            backgroundColor: isHovered ? "white" : style.bubbleBg,
+            width: "100%",
+            border: "1px solid rgba(0, 0, 0, 0.1)",
+          }}
+        >
+          {renderAssistantMessage(parsed.text)}
 
         {/* Render media items */}
         {parsed.media && parsed.media.length > 0 && (
@@ -231,6 +247,7 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
             })}
           </div>
         )}
+        </div>
       </div>
     );
   };

--- a/components/GroupChatPanel.tsx
+++ b/components/GroupChatPanel.tsx
@@ -131,9 +131,9 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
     return { parentMessages: parents, threadMap: map };
   }, [messages]);
 
-
   // Auto-scroll based on parent messages only (not threaded replies)
-  const { messagesEndRef, messagesContainerRef } = useAutoScroll(parentMessages);
+  const { messagesEndRef, messagesContainerRef } =
+    useAutoScroll(parentMessages);
 
   // Determine if we're waiting for a threaded reply
   const lastMessage = messages[messages.length - 1];
@@ -199,8 +199,12 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
     return (
       <div style={{ width: "85%" }}>
         {sourceContextText && (
-          <div className="text-xs text-gray-500 mb-1.5 pl-2 py-1 border-l-2 border-gray-300 bg-gray-50 rounded">
-            <span className="font-medium">
+          <div
+            className="text-xs text-gray-600 mb-1.5 pl-2 py-1 border-l-2 border-gray-300 bg-gray-50 rounded"
+            role="note"
+            aria-label="Voice reply context"
+          >
+            <span className="font-medium" aria-hidden="true">
               {isVoiceReply ? "🔊 " : ""}In reply to:{" "}
             </span>
             {sourceContextText}
@@ -216,37 +220,37 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
         >
           {renderAssistantMessage(parsed.text)}
 
-        {/* Render media items */}
-        {parsed.media && parsed.media.length > 0 && (
-          <div
-            style={{
-              marginTop: "0.5rem",
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.5rem",
-            }}
-          >
-            {parsed.media.map((item, index) => {
-              if (item.type === "image") {
-                return (
-                  <img
-                    key={`media-${index}`}
-                    src={`data:${item.mimeType};base64,${item.data}`}
-                    alt="Visual response"
-                    style={{
-                      maxWidth: "100%",
-                      height: "auto",
-                      borderRadius: "8px",
-                      border: "1px solid rgba(0, 0, 0, 0.1)",
-                    }}
-                  />
-                );
-              }
-              // Future: handle audio, video types here
-              return null;
-            })}
-          </div>
-        )}
+          {/* Render media items */}
+          {parsed.media && parsed.media.length > 0 && (
+            <div
+              style={{
+                marginTop: "0.5rem",
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.5rem",
+              }}
+            >
+              {parsed.media.map((item, index) => {
+                if (item.type === "image") {
+                  return (
+                    <img
+                      key={`media-${index}`}
+                      src={`data:${item.mimeType};base64,${item.data}`}
+                      alt="Visual response"
+                      style={{
+                        maxWidth: "100%",
+                        height: "auto",
+                        borderRadius: "8px",
+                        border: "1px solid rgba(0, 0, 0, 0.1)",
+                      }}
+                    />
+                  );
+                }
+                // Future: handle audio, video types here
+                return null;
+              })}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -337,7 +341,11 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
                   feedbackConfig={feedbackConfig}
                   showTimestamp={showTimestamp}
                   isThreadOpen={selectedThreadId === message.id}
-                  hasUnreadReplies={message.id ? messagesWithUnreadReplies.has(message.id) : false}
+                  hasUnreadReplies={
+                    message.id
+                      ? messagesWithUnreadReplies.has(message.id)
+                      : false
+                  }
                 />
               );
             })}

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -24,6 +24,7 @@ export interface ParsedMessageBody {
   type?: string;
   message?: string;
   media?: MediaItem[];
+  source?: string;
   sourceMessage?: string;
 }
 
@@ -41,6 +42,7 @@ export const parseMessageBody = (body: string | object): ParsedMessageBody => {
       type: obj.type?.toString(),
       message: obj.message?.toString(),
       media: Array.isArray(obj.media) ? obj.media : undefined,
+      source: obj.source?.toString(),
       sourceMessage: obj.sourceMessage?.toString(),
     };
   }


### PR DESCRIPTION
## What is in this PR?

when using 'Hey [botname]' support, the agent answers in group chat. This adds context of the original voice question, similar to how visual responses are shown in the Berkie panel. The banner has a speaker emoji and says In reply to [first 60 chars of voice message]

## Changes in the codebase

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Test with BE PR https://github.com/berkmancenter/llm_engine/pull/89. See test steps there


## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
