### PR TITLE
remove support of eventAssistantPlus conversation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This view displays what an event participant uses to send in questions and feedb
 
 ### Assistant (participant)
 
-This view is for event participants to interact with Event Assistant or Event Assistant Plus. It provides an interface to send and receive direct messages with the agent, and with Event Assistant Plus, to send messages to the moderator. If the event has enabled it and it is provided in the URL as a parameter, a transcript view is also visible.
+This view is for event participants to interact with Event Assistant. It provides an interface to send and receive direct messages with the agent, and if the moderator support feature is enabled, to send messages to the moderator. If the event has enabled it and it is provided in the URL as a parameter, a transcript view is also visible.
 
 ## Getting Started
 

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -235,8 +235,8 @@ const mockConfig = {
       ],
     },
     {
-      name: "eventAssistantPlus",
-      label: "Event Assistant Plus",
+      name: "eventAssistantExtraTest",
+      label: "Event Assistant With Additional Features",
       description: "A combination of Event Assistant and Back Channel",
       properties: [
         {
@@ -1496,8 +1496,8 @@ describe("EventCreationForm Component", () => {
       });
     });
 
-    it("shows only the organizer-configured features for Event Assistant Plus", async () => {
-      // This test is an explicit allowlist. If you add a new feature to eventAssistantPlus
+    it("shows only the organizer-configured features for Event Assistant Extra Test", async () => {
+      // This test is an explicit allowlist. If you add a new feature to the test type eventAssistantExtraTest
       // and it should appear in the event creation form (userControlled: false), add it here.
       // If it should NOT appear (userControlled: true), add it to the "should not appear" block.
       const user = userEvent.setup();
@@ -1513,7 +1513,9 @@ describe("EventCreationForm Component", () => {
       await waitFor(() => screen.getByText("Nextspace"));
       await user.click(screen.getByRole("checkbox", { name: /zoom/i }));
       await user.click(
-        screen.getByRole("radio", { name: /event assistant plus/i }),
+        screen.getByRole("radio", {
+          name: /event assistant with additional features/i,
+        }),
       );
       await user.click(screen.getByRole("button", { name: /next/i }));
       await waitFor(() => screen.getByText("Features"));

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -11,6 +11,8 @@ import { RetrieveData, Request } from "../../utils";
 import { Api } from "../../utils/Helpers";
 import "@testing-library/jest-dom";
 
+jest.setTimeout(60000);
+
 // Mock next/router
 const mockPush = jest.fn();
 jest.mock("next/router", () => ({
@@ -1697,7 +1699,9 @@ describe("EventCreationForm Component", () => {
         screen.getByRole("radio", { name: /create new series/i }),
       );
 
-      expect(screen.getByRole("checkbox", { name: /public/i })).not.toBeChecked();
+      expect(
+        screen.getByRole("checkbox", { name: /public/i }),
+      ).not.toBeChecked();
     });
 
     it("shows error when Next is clicked with empty series name", async () => {
@@ -1719,9 +1723,7 @@ describe("EventCreationForm Component", () => {
       await user.click(screen.getByRole("button", { name: /next/i }));
 
       await waitFor(() => {
-        expect(
-          screen.getByText("Series name is required"),
-        ).toBeInTheDocument();
+        expect(screen.getByText("Series name is required")).toBeInTheDocument();
       });
     });
 
@@ -1866,10 +1868,7 @@ describe("EventCreationForm Component", () => {
           expect.objectContaining({ topicId: "topic-1" }),
         );
         // Should NOT have called topics POST to create a new topic
-        expect(Request).not.toHaveBeenCalledWith(
-          "topics",
-          expect.anything(),
-        );
+        expect(Request).not.toHaveBeenCalledWith("topics", expect.anything());
       });
     });
   });

--- a/__tests__/components/GroupChatPanel.test.tsx
+++ b/__tests__/components/GroupChatPanel.test.tsx
@@ -384,78 +384,6 @@ describe("GroupChatPanel", () => {
     expect(screen.getByText("Object message")).toBeInTheDocument();
   });
 
-  it("normalizes 'Event Assistant Plus' to 'Berkie'", () => {
-    const messages = [
-      {
-        id: "1",
-        pseudonym: "Event Assistant Plus",
-        createdAt: "2025-10-17T12:00:00Z",
-        body: { text: "Hello from EA Plus" },
-        channels: ["chat"],
-        conversation: "conv-1",
-        pseudonymId: "ea-plus-1",
-        fromAgent: true,
-        pause: false,
-        visible: true,
-        upVotes: [],
-        downVotes: [],
-      },
-    ];
-
-    render(<GroupChatPanel {...baseProps} messages={messages} />);
-
-    expect(screen.getByText("Berkie")).toBeInTheDocument();
-    expect(screen.queryByText("Event Assistant Plus")).not.toBeInTheDocument();
-  });
-
-  it("normalizes 'Event Mediator' to 'Berkie'", () => {
-    const messages = [
-      {
-        id: "1",
-        pseudonym: "Event Mediator",
-        createdAt: "2025-10-17T12:00:00Z",
-        body: { text: "Hello from Event Mediator" },
-        channels: ["chat"],
-        conversation: "conv-1",
-        pseudonymId: "em-1",
-        fromAgent: true,
-        pause: false,
-        visible: true,
-        upVotes: [],
-        downVotes: [],
-      },
-    ];
-
-    render(<GroupChatPanel {...baseProps} messages={messages} />);
-
-    expect(screen.getByText("Berkie")).toBeInTheDocument();
-    expect(screen.queryByText("Event Mediator")).not.toBeInTheDocument();
-  });
-
-  it("normalizes 'Event Mediator Plus' to 'Berkie'", () => {
-    const messages = [
-      {
-        id: "1",
-        pseudonym: "Event Mediator Plus",
-        createdAt: "2025-10-17T12:00:00Z",
-        body: { text: "Hello from Event Mediator Plus" },
-        channels: ["chat"],
-        conversation: "conv-1",
-        pseudonymId: "em-plus-1",
-        fromAgent: true,
-        pause: false,
-        visible: true,
-        upVotes: [],
-        downVotes: [],
-      },
-    ];
-
-    render(<GroupChatPanel {...baseProps} messages={messages} />);
-
-    expect(screen.getByText("Berkie")).toBeInTheDocument();
-    expect(screen.queryByText("Event Mediator Plus")).not.toBeInTheDocument();
-  });
-
   it("normalizes 'Engagement Agent' to 'Berkie'", () => {
     const messages = [
       {
@@ -511,37 +439,6 @@ describe("GroupChatPanel", () => {
     expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
   });
 
-  it("applies assistant avatar and background color to Event Assistant Plus messages", () => {
-    const messages = [
-      {
-        id: "1",
-        pseudonym: "Event Assistant Plus",
-        createdAt: "2025-10-17T12:00:00Z",
-        body: { text: "Hello from Event Assistant Plus" },
-        channels: ["chat"],
-        conversation: "conv-1",
-        pseudonymId: "ea-plus-1",
-        fromAgent: true,
-        pause: false,
-        visible: true,
-        upVotes: [],
-        downVotes: [],
-      },
-    ];
-
-    const { container } = render(
-      <GroupChatPanel {...baseProps} messages={messages} />,
-    );
-
-    // Check that the avatar has the purple background color (#DDD6FE)
-    const avatar = container.querySelector(".rounded-full");
-    expect(avatar).toHaveStyle({ backgroundColor: "#DDD6FE" });
-
-    // Check that the message bubble has the purple background color (#DDD6FE)
-    const messageBubble = container.querySelector(".rounded-2xl");
-    expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
-  });
-
   it("applies assistant avatar and background color to Event Mediator messages", () => {
     const messages = [
       {
@@ -571,77 +468,6 @@ describe("GroupChatPanel", () => {
     // Check that the message bubble has the purple background color (#DDD6FE)
     const messageBubble = container.querySelector(".rounded-2xl");
     expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
-  });
-
-  it("applies assistant avatar and background color to Event Mediator Plus messages", () => {
-    const messages = [
-      {
-        id: "1",
-        pseudonym: "Event Mediator Plus",
-        createdAt: "2025-10-17T12:00:00Z",
-        body: { text: "Hello from Event Mediator Plus" },
-        channels: ["chat"],
-        conversation: "conv-1",
-        pseudonymId: "em-plus-1",
-        fromAgent: true,
-        pause: false,
-        visible: true,
-        upVotes: [],
-        downVotes: [],
-      },
-    ];
-
-    const { container } = render(
-      <GroupChatPanel {...baseProps} messages={messages} />,
-    );
-
-    // Check that the avatar has the purple background color (#DDD6FE)
-    const avatar = container.querySelector(".rounded-full");
-    expect(avatar).toHaveStyle({ backgroundColor: "#DDD6FE" });
-
-    // Check that the message bubble has the purple background color (#DDD6FE)
-    const messageBubble = container.querySelector(".rounded-2xl");
-    expect(messageBubble).toHaveStyle({ backgroundColor: "#DDD6FE" });
-  });
-
-  it("normalizes 'Event Assistant Plus' to 'Event Assistant' in contributors for mentions", () => {
-    const messages = [
-      {
-        id: "1",
-        pseudonym: "Event Assistant Plus",
-        createdAt: "2025-10-17T12:00:00Z",
-        body: { text: "Hello from EA Plus" },
-        channels: ["chat"],
-        conversation: "conv-1",
-        pseudonymId: "ea-plus-1",
-        fromAgent: true,
-        pause: false,
-        visible: true,
-        upVotes: [],
-        downVotes: [],
-      },
-      {
-        id: "2",
-        pseudonym: "Alice",
-        createdAt: "2025-10-17T12:01:00Z",
-        body: { text: "Hi there" },
-        channels: ["chat"],
-        conversation: "conv-1",
-        pseudonymId: "alice-1",
-        fromAgent: false,
-        pause: false,
-        visible: true,
-        upVotes: [],
-        downVotes: [],
-      },
-    ];
-
-    render(<GroupChatPanel {...baseProps} messages={messages} />);
-
-    // The MessageInput component should receive enhancers with normalized "Event Assistant"
-    // (not "Event Assistant Plus") in the contributors list
-    // This is tested implicitly through the mocked MessageInput component
-    expect(screen.getByTestId("message-input")).toBeInTheDocument();
   });
 
   describe("Visual message handling (media)", () => {

--- a/__tests__/components/MessageInput.Test.tsx
+++ b/__tests__/components/MessageInput.Test.tsx
@@ -19,7 +19,7 @@ describe("MessageInput Component", () => {
       command: "mod",
       description: "Submit a question to the moderator",
       value: "/mod ",
-      conversationTypes: ["eventAssistantPlus"],
+      conversationTypes: ["eventAssistant"],
     },
     {
       command: "test",

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -597,6 +597,86 @@ describe("EventAssistantRoom", () => {
         { timeout: 3000 },
       );
     });
+
+    it("does not show /mod command when the feature is disabled (enabled: false)", async () => {
+      mockRouter.query = {
+        conversationId: "test-conversation-id",
+        channel: "chat,test-chat-passcode",
+      };
+
+      mockUseSessionJoin.mockReturnValue({
+        socket: mockSocket,
+        pseudonym: "test-pseudonym",
+        userId: "user-123",
+        isConnected: true,
+        errorMessage: null,
+      });
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-456", agentType: "eventAssistant" }],
+          });
+        } else if (path.startsWith("messages/")) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve(null);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-456", agentType: "eventAssistant" }],
+        features: [{ name: "mod", enabled: false }],
+        type: {
+          name: "eventAssistantPlus",
+          description: "",
+          platforms: [],
+          properties: [],
+          features: [
+            {
+              name: "mod",
+              label: "Submit to Moderator",
+              tab: "chat",
+              audience: "participant",
+              slashCommand: "mod",
+              default: true,
+              agents: [],
+              description: "Submit a question to the moderator",
+            },
+          ],
+        },
+      });
+
+      await act(async () => {
+        render(
+          <ConversationTypeProvider>
+            <EventAssistantRoom authType={"guest"} />
+          </ConversationTypeProvider>,
+        );
+      });
+
+      await waitFor(() => {
+        expect(createConversationFromData).toHaveBeenCalled();
+      });
+
+      const user = userEvent.setup();
+
+      const assistantTabs = screen.getAllByLabelText("Berkie");
+      await user.click(assistantTabs[0]);
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("Enter your message here"),
+        ).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText("Enter your message here");
+      await user.type(input, "/");
+
+      await waitFor(
+        () => {
+          expect(screen.queryByText("/mod")).not.toBeInTheDocument();
+        },
+        { timeout: 3000 },
+      );
+    });
   });
 
   describe("Bot @mention routing in chat tab", () => {

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -89,7 +89,11 @@ jest.mock("../../utils", () => ({
   buildDirectChannels: jest.fn((userId, agents, preferences) =>
     agents
       .filter((a: any) => !a.preferenceKey || preferences[a.preferenceKey])
-      .map((a: any) => ({ name: `direct-${userId}-${a.agentId}`, passcode: null, direct: true }))
+      .map((a: any) => ({
+        name: `direct-${userId}-${a.agentId}`,
+        passcode: null,
+        direct: true,
+      })),
   ),
 }));
 
@@ -443,7 +447,7 @@ describe("EventAssistantRoom", () => {
   });
 
   describe("Conversation-Type-Specific Commands", () => {
-    it("shows /mod command for Event Assistant Plus", async () => {
+    it("shows /mod command for Event Assistant", async () => {
       // Set up router query with channel and chat passcode
       mockRouter.query = {
         conversationId: "test-conversation-id",
@@ -460,7 +464,7 @@ describe("EventAssistantRoom", () => {
       (RetrieveData as jest.Mock).mockImplementation((path: string) => {
         if (path.startsWith("conversations/")) {
           return Promise.resolve({
-            agents: [{ id: "agent-456", agentType: "eventAssistantPlus" }],
+            agents: [{ id: "agent-456", agentType: "eventAssistant" }],
           });
         } else if (path.startsWith("messages/")) {
           return Promise.resolve([]);
@@ -468,9 +472,9 @@ describe("EventAssistantRoom", () => {
         return Promise.resolve(null);
       });
       (createConversationFromData as jest.Mock).mockResolvedValue({
-        agents: [{ id: "agent-456", agentType: "eventAssistantPlus" }],
+        agents: [{ id: "agent-456", agentType: "eventAssistant" }],
         type: {
-          name: "eventAssistantPlus",
+          name: "eventAssistant",
           description: "",
           platforms: [],
           properties: [],
@@ -493,7 +497,7 @@ describe("EventAssistantRoom", () => {
         render(
           <ConversationTypeProvider>
             <EventAssistantRoom authType={"guest"} />
-          </ConversationTypeProvider>
+          </ConversationTypeProvider>,
         );
       });
 
@@ -553,14 +557,20 @@ describe("EventAssistantRoom", () => {
       });
       (createConversationFromData as jest.Mock).mockResolvedValue({
         agents: [{ id: "agent-456", agentType: "eventAssistant" }],
-        type: { name: "eventAssistant", description: "", platforms: [], properties: [], features: [] },
+        type: {
+          name: "eventAssistant",
+          description: "",
+          platforms: [],
+          properties: [],
+          features: [],
+        },
       });
 
       await act(async () => {
         render(
           <ConversationTypeProvider>
             <EventAssistantRoom authType={"guest"} />
-          </ConversationTypeProvider>
+          </ConversationTypeProvider>,
         );
       });
 
@@ -1899,17 +1909,22 @@ describe("EventAssistantRoom", () => {
     it("displays jargon clarification messages inline in the assistant panel when jargonFilterAgentId is set", async () => {
       const conversationWithJargon = {
         agents: [
-          { id: "agent-123", agentType: "eventAssistantPlus" },
+          { id: "agent-123", agentType: "eventAssistant" },
           { id: "jargon-agent-456", agentType: "jargonFilterAgent" },
         ],
-        type: { name: "eventAssistantPlus" },
+        type: { name: "eventAssistant" },
       };
-      (createConversationFromData as jest.Mock).mockResolvedValue(conversationWithJargon);
+      (createConversationFromData as jest.Mock).mockResolvedValue(
+        conversationWithJargon,
+      );
 
       (RetrieveData as jest.Mock).mockImplementation((path: string) => {
         if (path.startsWith("conversations/")) {
           return Promise.resolve(conversationWithJargon);
-        } else if (path.includes("users/user/") && path.includes("/preferences")) {
+        } else if (
+          path.includes("users/user/") &&
+          path.includes("/preferences")
+        ) {
           return Promise.resolve({ jargonClarification: true });
         } else if (path.startsWith("messages/")) {
           return Promise.resolve([]);
@@ -1923,7 +1938,10 @@ describe("EventAssistantRoom", () => {
 
       // Wait for jargonFilterAgentId to be set from conversation data
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith(
+          "message:new",
+          expect.any(Function),
+        );
       });
 
       // Retrieve the most recently registered message:new handler — it has jargonFilterAgentId in its closure
@@ -1938,7 +1956,11 @@ describe("EventAssistantRoom", () => {
       // Simulate a jargon clarification message arriving on the jargon filter's direct channel
       const jargonMessage = {
         id: "msg-jargon-1",
-        body: { type: "jargon_clarification", text: "An SLO is a reliability target.", sourceText: "Our SLOs..." },
+        body: {
+          type: "jargon_clarification",
+          text: "An SLO is a reliability target.",
+          sourceText: "Our SLOs...",
+        },
         bodyType: "json",
         fromAgent: true,
         channels: ["direct-user-123-jargon-agent-456"],
@@ -1966,7 +1988,9 @@ describe("EventAssistantRoom", () => {
 
       // Verify the jargon clarification content appears inline in the assistant panel
       await waitFor(() => {
-        expect(screen.getByText("An SLO is a reliability target.")).toBeInTheDocument();
+        expect(
+          screen.getByText("An SLO is a reliability target."),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -2068,7 +2092,9 @@ describe("EventAssistantRoom", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByPlaceholderText("Enter your message here")).toBeInTheDocument();
+        expect(
+          screen.getByPlaceholderText("Enter your message here"),
+        ).toBeInTheDocument();
       });
 
       // Simulate the component calling sendMessage with prompt response parameters
@@ -2236,7 +2262,9 @@ describe("EventAssistantRoom", () => {
       expect(screen.queryByText(/^Yes$/)).not.toBeInTheDocument();
 
       // The follow-up message should be visible
-      expect(screen.getByText("Great! Here's how I can help...")).toBeInTheDocument();
+      expect(
+        screen.getByText("Great! Here's how I can help..."),
+      ).toBeInTheDocument();
     });
 
     it("restores selected prompt option on page load when response exists", async () => {
@@ -2355,7 +2383,9 @@ describe("EventAssistantRoom", () => {
         render(<EventAssistantRoom authType={"guest"} />);
       });
 
-      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(createConversationFromData).toHaveBeenCalled(),
+      );
     };
 
     /** Grab the most recently registered message:new handler from the socket mock. */
@@ -2398,7 +2428,10 @@ describe("EventAssistantRoom", () => {
       const mockResourcesMessages = [
         {
           id: "res-1",
-          body: { type: "reading", content: [{ title: "Book A", authors: ["A"], year: 2020 }] },
+          body: {
+            type: "reading",
+            content: [{ title: "Book A", authors: ["A"], year: 2020 }],
+          },
           channels: ["resources"],
         },
       ];
@@ -2446,7 +2479,10 @@ describe("EventAssistantRoom", () => {
       await user.click(resourcesTab);
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith(
+          "message:new",
+          expect.any(Function),
+        );
       });
 
       const messageHandler = getMessageHandler();
@@ -2470,14 +2506,24 @@ describe("EventAssistantRoom", () => {
       await resourcesSetup();
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith(
+          "message:new",
+          expect.any(Function),
+        );
       });
 
       const messageHandler = getMessageHandler();
 
       // Default tab is chat — unseen count should increment, showing the dot badge
       act(() => {
-        messageHandler({ id: "res-1", channels: ["resources"], body: { type: "reading", content: [{ title: "Book A", authors: ["Author"], year: 2020 }] } });
+        messageHandler({
+          id: "res-1",
+          channels: ["resources"],
+          body: {
+            type: "reading",
+            content: [{ title: "Book A", authors: ["Author"], year: 2020 }],
+          },
+        });
       });
 
       // NavigationBar uses MUI Badge dot variant — a visible badge has no MuiBadge-invisible class
@@ -2497,13 +2543,20 @@ describe("EventAssistantRoom", () => {
       await user.click(screen.getAllByLabelText("Resources")[0]);
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith(
+          "message:new",
+          expect.any(Function),
+        );
       });
 
       const messageHandler = getMessageHandler();
 
       act(() => {
-        messageHandler({ id: "res-1", channels: ["resources"], body: { type: "reading", content: [] } });
+        messageHandler({
+          id: "res-1",
+          channels: ["resources"],
+          body: { type: "reading", content: [] },
+        });
       });
 
       // No dot badge should be visible since we're already on the resources tab
@@ -2520,7 +2573,10 @@ describe("EventAssistantRoom", () => {
       await resourcesSetup();
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith(
+          "message:new",
+          expect.any(Function),
+        );
       });
 
       const messageHandler = getMessageHandler();
@@ -2567,13 +2623,20 @@ describe("EventAssistantRoom", () => {
       await resourcesSetup();
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith(
+          "message:new",
+          expect.any(Function),
+        );
       });
 
       const messageHandler = getMessageHandler();
 
       act(() => {
-        messageHandler({ id: "res-1", channels: ["resources"], body: { text: "Resources only" } });
+        messageHandler({
+          id: "res-1",
+          channels: ["resources"],
+          body: { text: "Resources only" },
+        });
       });
 
       // Switch to assistant tab and confirm the message isn't rendered there
@@ -2589,7 +2652,10 @@ describe("EventAssistantRoom", () => {
       await resourcesSetup();
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith("message:new", expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith(
+          "message:new",
+          expect.any(Function),
+        );
       });
 
       const messageHandler = getMessageHandler();
@@ -2654,7 +2720,9 @@ describe("EventAssistantRoom", () => {
         render(<EventAssistantRoom authType={"guest"} />);
       });
 
-      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(createConversationFromData).toHaveBeenCalled(),
+      );
 
       expect(screen.getAllByLabelText("Resources").length).toBeGreaterThan(0);
     });
@@ -2680,7 +2748,9 @@ describe("EventAssistantRoom", () => {
         render(<EventAssistantRoom authType={"guest"} />);
       });
 
-      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(createConversationFromData).toHaveBeenCalled(),
+      );
 
       const resourcesFetch = (RetrieveData as jest.Mock).mock.calls.find(
         ([path]: [string]) => path.includes("channel=resources"),

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -303,7 +303,7 @@ describe("EventAssistantRoom", () => {
     });
   });
 
-  it("displays error when conversation has no event assistant agent", async () => {
+  it("shows inactive notice when conversation has no event assistant agent", async () => {
     (RetrieveData as jest.Mock).mockResolvedValue({
       agents: [{ id: "agent-123", agentType: "regular" }],
     });
@@ -316,11 +316,13 @@ describe("EventAssistantRoom", () => {
       render(<EventAssistantRoom authType={"guest"} />);
     });
 
+    await act(async () => {
+      await userEvent.click(screen.getAllByRole("button", { name: "Berkie" })[0]);
+    });
+
     await waitFor(() => {
       expect(
-        screen.getByText(
-          "This conversation does not have an event assistant agent.",
-        ),
+        screen.getByText("This event has ended. Berkie is no longer active."),
       ).toBeInTheDocument();
     });
   });
@@ -830,11 +832,13 @@ describe("EventAssistantRoom", () => {
         expect(createConversationFromData).toHaveBeenCalled();
       });
 
-      // Error is shown because there's no event assistant agent, but botName defaults to "Berkie"
+      await act(async () => {
+        await userEvent.click(screen.getAllByRole("button", { name: "Berkie" })[0]);
+      });
+
+      // Inactive notice is shown because there's no event assistant agent, using default botName "Berkie"
       expect(
-        screen.getByText(
-          "This conversation does not have an event assistant agent.",
-        ),
+        screen.getByText("This event has ended. Berkie is no longer active."),
       ).toBeInTheDocument();
     });
   });

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -317,7 +317,9 @@ describe("EventAssistantRoom", () => {
     });
 
     await act(async () => {
-      await userEvent.click(screen.getAllByRole("button", { name: "Berkie" })[0]);
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Berkie" })[0],
+      );
     });
 
     await waitFor(() => {
@@ -533,7 +535,7 @@ describe("EventAssistantRoom", () => {
       );
     });
 
-    it("does not show /mod command for Event Assistant (non-Plus)", async () => {
+    it("does not show /mod command for Event Assistant without moderator feature", async () => {
       // Set up router query with channel and chat passcode
       mockRouter.query = {
         conversationId: "test-conversation-id",
@@ -627,7 +629,7 @@ describe("EventAssistantRoom", () => {
         agents: [{ id: "agent-456", agentType: "eventAssistant" }],
         features: [{ name: "mod", enabled: false }],
         type: {
-          name: "eventAssistantPlus",
+          name: "eventAssistant",
           description: "",
           platforms: [],
           properties: [],
@@ -833,7 +835,9 @@ describe("EventAssistantRoom", () => {
       });
 
       await act(async () => {
-        await userEvent.click(screen.getAllByRole("button", { name: "Berkie" })[0]);
+        await userEvent.click(
+          screen.getAllByRole("button", { name: "Berkie" })[0],
+        );
       });
 
       // Inactive notice is shown because there's no event assistant agent, using default botName "Berkie"

--- a/__tests__/pages/guide.test.tsx
+++ b/__tests__/pages/guide.test.tsx
@@ -84,6 +84,25 @@ const GUIDE_RESPONSE_WITH_DISABLED = {
   ],
 };
 
+// slashCommand + enabled: false → "Not available" pill per row
+const GUIDE_RESPONSE_WITH_DISABLED_SLASH = {
+  ...GUIDE_RESPONSE,
+  features: [
+    {
+      name: "mindmap",
+      label: "Mind Map",
+      category: "assistant",
+      slashCommand: "mindmap",
+      userControlled: true,
+      default: true,
+      enabled: false,
+      agents: [],
+      description: "Generate a visual mind map.",
+    },
+    ...GUIDE_RESPONSE.features.slice(1),
+  ],
+};
+
 // userControlled: false + enabled: false → "Not available" pill
 const GUIDE_RESPONSE_WITH_UNAVAILABLE = {
   ...GUIDE_RESPONSE,
@@ -159,6 +178,44 @@ describe("GuidePage", () => {
     render(<GuidePage />);
     await waitFor(() =>
       expect(screen.getByText("/mindmap")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows 'Active' pill for an enabled slash command", async () => {
+    resolveWith(GUIDE_RESPONSE);
+    render(<GuidePage />);
+    await waitFor(() => {
+      expect(screen.getByText("/mindmap")).toBeInTheDocument();
+      // Multiple Active pills may exist (one per enabled slash command row)
+      expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows 'Not available' pill for a disabled slash command", async () => {
+    resolveWith(GUIDE_RESPONSE_WITH_DISABLED_SLASH);
+    render(<GuidePage />);
+    await waitFor(() => {
+      expect(screen.getByText("/mindmap")).toBeInTheDocument();
+      expect(screen.getByText("Not available")).toBeInTheDocument();
+    });
+  });
+
+  it("marks a disabled slash command row with aria-disabled", async () => {
+    resolveWith(GUIDE_RESPONSE_WITH_DISABLED_SLASH);
+    render(<GuidePage />);
+    await waitFor(() => {
+      const row = screen.getByText("/mindmap").closest("[aria-disabled]");
+      expect(row).toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  it("shows caveat when a slash command is disabled", async () => {
+    resolveWith(GUIDE_RESPONSE_WITH_DISABLED_SLASH);
+    render(<GuidePage />);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/feature availability varies by event/i),
+      ).toBeInTheDocument(),
     );
   });
 

--- a/__tests__/pages/guide.test.tsx
+++ b/__tests__/pages/guide.test.tsx
@@ -18,7 +18,7 @@ const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
 const GUIDE_RESPONSE = {
-  conversationType: "eventAssistantPlus",
+  conversationType: "eventAssistant",
   conversationBotName: "TestBot",
   features: [
     {

--- a/__tests__/pages/moderator.test.tsx
+++ b/__tests__/pages/moderator.test.tsx
@@ -121,15 +121,16 @@ describe("ModeratorScreen", () => {
     },
     {
       id: "3",
-      pseudonym: "Event Mediator Plus",
+      pseudonym: "Event Mediator",
       createdAt: "2026-03-13T00:31:29.268Z",
       channels: ["moderator"],
       body: {
         insights: [
           {
-            value: "At least 2 participants are independently reporting they cannot hear the speaker/audio.",
-            type: "insight"
-          }
+            value:
+              "At least 2 participants are independently reporting they cannot hear the speaker/audio.",
+            type: "insight",
+          },
         ],
         timestamp: {
           start: 1773361630922,
@@ -238,9 +239,10 @@ describe("ModeratorScreen", () => {
     // Simulate token rotation: the singleton returns a new token after the
     // component has already mounted. The page must read the singleton on every
     // call rather than capturing the value at render time.
-    const mockGetTokens = jest.fn()
+    const mockGetTokens = jest
+      .fn()
       .mockReturnValueOnce({ access: "initial-token" }) // first read (useEffect guard)
-      .mockReturnValue({ access: "rotated-token" });    // all subsequent reads
+      .mockReturnValue({ access: "rotated-token" }); // all subsequent reads
 
     const { Api: MockApi } = require("../../utils");
     MockApi.get.mockReturnValue({
@@ -269,7 +271,9 @@ describe("ModeratorScreen", () => {
   });
 
   it("uses fresh token from Api singleton when re-fetching after gap-reconnect", async () => {
-    const mockGetTokens = jest.fn().mockReturnValue({ access: "fresh-token-after-reconnect" });
+    const mockGetTokens = jest
+      .fn()
+      .mockReturnValue({ access: "fresh-token-after-reconnect" });
     const { Api: MockApi } = require("../../utils");
     MockApi.get.mockReturnValue({
       SetTokens: jest.fn(),
@@ -291,7 +295,7 @@ describe("ModeratorScreen", () => {
     }));
 
     const { rerender } = await act(async () =>
-      render(<ModeratorScreen authType={"user"} />)
+      render(<ModeratorScreen authType={"user"} />),
     );
 
     // Simulate a gap-reconnect by re-rendering with a non-null lastReconnectTime
@@ -312,8 +316,10 @@ describe("ModeratorScreen", () => {
     await waitFor(() => {
       const retrieveDataCalls = (RetrieveData as jest.Mock).mock.calls;
       // At least one call should be the gap-reconnect re-fetch for moderator messages
-      const reconnectFetch = retrieveDataCalls.find(([url]) =>
-        url.includes("messages/test-conversation") && url.includes("moderator")
+      const reconnectFetch = retrieveDataCalls.find(
+        ([url]) =>
+          url.includes("messages/test-conversation") &&
+          url.includes("moderator"),
       );
       expect(reconnectFetch).toBeDefined();
       // It must use the current token from the singleton, not a stale string
@@ -321,21 +327,21 @@ describe("ModeratorScreen", () => {
     });
   });
 
-  it("renders insights from Event Mediator Plus pseudonym correctly", async () => {
+  it("renders insights from Event Mediator pseudonym correctly", async () => {
     await act(async () => {
       render(<ModeratorScreen authType={"user"} />);
     });
 
     await waitFor(() => {
       expect(
-        screen.getByText(/At least 2 participants are independently reporting/)
+        screen.getByText(/At least 2 participants are independently reporting/),
       ).toBeInTheDocument();
     });
   });
 
   it("logs unknown message formats to console instead of displaying them", async () => {
     const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-    
+
     const messagesWithUnknown = [
       ...mockMessages,
       {
@@ -364,16 +370,18 @@ describe("ModeratorScreen", () => {
     await waitFor(() => {
       // Check that console.log was called with the unknown message
       const unknownMessageCalls = consoleLogSpy.mock.calls.filter(
-        (call) => call[0] === "Unknown message format:"
+        (call) => call[0] === "Unknown message format:",
       );
       expect(unknownMessageCalls.length).toBeGreaterThan(0);
       expect(unknownMessageCalls[0][1]).toMatchObject({
         id: "4",
         pseudonym: "Unknown Agent",
       });
-      
+
       // Ensure "Unknown message format" text is NOT displayed in the UI
-      expect(screen.queryByText("Unknown message format")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Unknown message format"),
+      ).not.toBeInTheDocument();
     });
 
     consoleLogSpy.mockRestore();
@@ -405,14 +413,14 @@ describe("ModeratorScreen", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Custom insight from non-standard agent")
+        screen.getByText("Custom insight from non-standard agent"),
       ).toBeInTheDocument();
     });
   });
 
   it("logs messages with metrics property that is not an array", async () => {
     const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-    
+
     const messagesWithInvalidMetrics = [
       {
         id: "6",
@@ -437,7 +445,7 @@ describe("ModeratorScreen", () => {
 
     await waitFor(() => {
       const unknownMessageCalls = consoleLogSpy.mock.calls.filter(
-        (call) => call[0] === "Unknown message format:"
+        (call) => call[0] === "Unknown message format:",
       );
       expect(unknownMessageCalls.length).toBeGreaterThan(0);
       expect(unknownMessageCalls[0][1]).toMatchObject({
@@ -451,7 +459,7 @@ describe("ModeratorScreen", () => {
 
   it("logs messages with preset but no text property", async () => {
     const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-    
+
     const messagesWithPartialPreset = [
       {
         id: "7",
@@ -479,7 +487,7 @@ describe("ModeratorScreen", () => {
 
     await waitFor(() => {
       const unknownMessageCalls = consoleLogSpy.mock.calls.filter(
-        (call) => call[0] === "Unknown message format:"
+        (call) => call[0] === "Unknown message format:",
       );
       expect(unknownMessageCalls.length).toBeGreaterThan(0);
       expect(unknownMessageCalls[0][1]).toMatchObject({

--- a/__tests__/utils/Helpers.test.ts
+++ b/__tests__/utils/Helpers.test.ts
@@ -317,9 +317,7 @@ describe("generateEventUrls (via createConversationFromData)", () => {
   const mockConfig = {
     conversationTypes: [
       { id: "1", name: "eventAssistant" },
-      { id: "2", name: "eventAssistantPlus" },
-      { id: "3", name: "eventAssistantPlusProactive" },
-      { id: "4", name: "backChannel" },
+      { id: "2", name: "backChannel" },
     ],
     availablePlatforms: [],
     conversationBotName: "Berkie",
@@ -366,28 +364,16 @@ describe("generateEventUrls (via createConversationFromData)", () => {
     expect(url).toContain("channel=resources,res-secret");
   });
 
-  it("appends resources channel param for eventAssistantPlus", async () => {
+  it("appends resources channel param for eventAssistant", async () => {
     const data = {
       ...baseConversation,
-      conversationType: "eventAssistantPlus",
-      agents: [{ id: "agent-1", agentType: "eventAssistantPlus" }],
+      conversationType: "eventAssistant",
+      agents: [{ id: "agent-1", agentType: "eventAssistant" }],
       channels: [{ name: "resources", passcode: "res-plus" }],
     };
     const result = await createConversationFromData(data as any);
     const url = result.eventUrls.participant[0]?.url;
     expect(url).toContain("channel=resources,res-plus");
-  });
-
-  it("appends resources channel param for eventAssistantPlusProactive", async () => {
-    const data = {
-      ...baseConversation,
-      conversationType: "eventAssistantPlusProactive",
-      agents: [{ id: "agent-1", agentType: "eventAssistantPlusProactive" }],
-      channels: [{ name: "resources", passcode: "res-proactive" }],
-    };
-    const result = await createConversationFromData(data as any);
-    const url = result.eventUrls.participant[0]?.url;
-    expect(url).toContain("channel=resources,res-proactive");
   });
 
   it("includes resources param after chat param when both channels exist", async () => {
@@ -423,6 +409,49 @@ describe("generateEventUrls (via createConversationFromData)", () => {
     expect(url).toContain("channel=chat,chat-pass");
     expect(url).toContain("channel=resources,res-pass");
   });
+
+  it("includes a moderator URL when moderatorSupport feature is enabled and moderator channel exists", async () => {
+    const data = {
+      ...baseConversation,
+      channels: [{ name: "moderator", passcode: "mod-pass" }],
+      features: [{ name: "moderatorSupport", enabled: true }],
+    };
+    const result = await createConversationFromData(data as any);
+    expect(result.eventUrls.moderator.length).toBe(1);
+    expect(result.eventUrls.moderator[0].url).toContain(
+      "channel=moderator,mod-pass",
+    );
+  });
+
+  it("excludes moderator URL when moderatorSupport feature is absent from conversation features", async () => {
+    const data = {
+      ...baseConversation,
+      channels: [{ name: "moderator", passcode: "mod-pass" }],
+      features: [],
+    };
+    const result = await createConversationFromData(data as any);
+    expect(result.eventUrls.moderator.length).toBe(0);
+  });
+
+  it("excludes moderator URL when moderatorSupport feature is explicitly disabled", async () => {
+    const data = {
+      ...baseConversation,
+      channels: [{ name: "moderator", passcode: "mod-pass" }],
+      features: [{ name: "moderatorSupport", enabled: false }],
+    };
+    const result = await createConversationFromData(data as any);
+    expect(result.eventUrls.moderator.length).toBe(0);
+  });
+
+  it("excludes moderator URL when moderatorSupport is enabled but no moderator channel exists", async () => {
+    const data = {
+      ...baseConversation,
+      channels: [],
+      features: [{ name: "moderatorSupport", enabled: true }],
+    };
+    const result = await createConversationFromData(data as any);
+    expect(result.eventUrls.moderator.length).toBe(0);
+  });
 });
 
 describe("GetChannelPasscode", () => {
@@ -431,24 +460,40 @@ describe("GetChannelPasscode", () => {
   beforeEach(() => noopError.mockClear());
 
   it("returns the passcode when the channel is present as a string", () => {
-    const result = GetChannelPasscode("chat", { channel: "chat,chat-secret" }, noopError);
+    const result = GetChannelPasscode(
+      "chat",
+      { channel: "chat,chat-secret" },
+      noopError,
+    );
     expect(result).toBe("chat-secret");
   });
 
   it("returns null when the channel is absent from a string query param", () => {
-    const result = GetChannelPasscode("resources", { channel: "chat,chat-secret" }, noopError);
+    const result = GetChannelPasscode(
+      "resources",
+      { channel: "chat,chat-secret" },
+      noopError,
+    );
     expect(result).toBeNull();
     expect(noopError).not.toHaveBeenCalled();
   });
 
   it("returns the passcode when the channel is present in an array query param", () => {
-    const result = GetChannelPasscode("resources", { channel: ["chat,chat-pass", "resources,res-pass"] }, noopError);
+    const result = GetChannelPasscode(
+      "resources",
+      { channel: ["chat,chat-pass", "resources,res-pass"] },
+      noopError,
+    );
     expect(result).toBe("res-pass");
   });
 
   it("returns null (not another channel's passcode) when channel is absent from an array query param", () => {
     // Regression: previously returned the first channel's passcode when the target channel was missing
-    const result = GetChannelPasscode("resources", { channel: ["transcript,tx-pass", "chat,chat-pass"] }, noopError);
+    const result = GetChannelPasscode(
+      "resources",
+      { channel: ["transcript,tx-pass", "chat,chat-pass"] },
+      noopError,
+    );
     expect(result).toBeNull();
     expect(noopError).not.toHaveBeenCalled();
   });

--- a/__tests__/utils/feedbackEligibility.test.ts
+++ b/__tests__/utils/feedbackEligibility.test.ts
@@ -6,7 +6,7 @@ describe("getFeedbackEligibleMessages", () => {
   const createMessage = (
     id: string,
     fromAgent: boolean,
-    bodyType?: string
+    bodyType?: string,
   ): PseudonymousMessage => ({
     id,
     fromAgent,
@@ -71,21 +71,6 @@ describe("getFeedbackEligibleMessages", () => {
       expect(result.size).toBe(2);
     });
 
-    it("excludes unanswerable messages", () => {
-      const messages = [
-        createMessage("1", true),
-        createMessage("2", true, "unanswerable"),
-        createMessage("3", true),
-      ];
-
-      const result = getFeedbackEligibleMessages(messages, 1);
-
-      expect(result.has("1")).toBe(true);
-      expect(result.has("2")).toBe(false);
-      expect(result.has("3")).toBe(true);
-      expect(result.size).toBe(2);
-    });
-
     it("excludes moderator_offered messages", () => {
       const messages = [
         createMessage("1", true),
@@ -135,7 +120,6 @@ describe("getFeedbackEligibleMessages", () => {
       const messages = [
         createMessage("1", true),
         createMessage("2", true, "intro"),
-        createMessage("3", true, "unanswerable"),
         createMessage("4", true),
         createMessage("5", true, "moderator_offered"),
         createMessage("6", true, "moderator_submitted"),
@@ -148,7 +132,6 @@ describe("getFeedbackEligibleMessages", () => {
       // Only messages 1, 4, and 7 should be eligible
       expect(result.has("1")).toBe(true);
       expect(result.has("2")).toBe(false);
-      expect(result.has("3")).toBe(false);
       expect(result.has("4")).toBe(true);
       expect(result.has("5")).toBe(false);
       expect(result.has("6")).toBe(false);
@@ -260,7 +243,6 @@ describe("getFeedbackEligibleMessages", () => {
         createMessage("1", true), // 1st eligible
         createMessage("2", true, "intro"), // excluded
         createMessage("3", true), // 2nd eligible - should show feedback
-        createMessage("4", true, "unanswerable"), // excluded
         createMessage("5", true), // 3rd eligible
         createMessage("6", true), // 4th eligible - should show feedback
       ];
@@ -271,7 +253,6 @@ describe("getFeedbackEligibleMessages", () => {
       expect(result.has("1")).toBe(false);
       expect(result.has("2")).toBe(false);
       expect(result.has("3")).toBe(true); // 2nd eligible
-      expect(result.has("4")).toBe(false);
       expect(result.has("5")).toBe(false);
       expect(result.has("6")).toBe(true); // 4th eligible
     });
@@ -353,10 +334,7 @@ describe("getFeedbackEligibleMessages", () => {
     });
 
     it("handles frequency larger than number of eligible messages", () => {
-      const messages = [
-        createMessage("1", true),
-        createMessage("2", true),
-      ];
+      const messages = [createMessage("1", true), createMessage("2", true)];
 
       const result = getFeedbackEligibleMessages(messages, 5);
 

--- a/components/AssistantChatPanel.tsx
+++ b/components/AssistantChatPanel.tsx
@@ -47,6 +47,7 @@ interface AssistantChatPanelProps {
   feedbackConfig?: FeedbackConfig;
   messagesWithUnreadReplies?: Set<string>;
   onMarkAsRead?: (messageId: string) => void;
+  inactive?: boolean;
 }
 
 export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
@@ -70,6 +71,7 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
   feedbackConfig,
   messagesWithUnreadReplies = new Set(),
   onMarkAsRead,
+  inactive = false,
 }) => {
   const [preferencesVisible, setPreferencesVisible] = useState(showPreferences);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
@@ -464,16 +466,22 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
 
         {/* MessageInput*/}
         <div className="flex-shrink-0">
-          <MessageInput
-            pseudonym={pseudonym}
-            enhancers={enhancers}
-            onSendMessage={onSendMessage}
-            waitingForResponse={waitingForResponse}
-            controlledMode={controlledMode}
-            onExitControlledMode={onExitControlledMode}
-            inputValue={inputValue}
-            onInputChange={onInputChange}
-          />
+          {inactive ? (
+            <div className="px-4 py-3 text-sm text-gray-500 italic text-center border-t border-gray-200">
+              This event has ended. {botName} is no longer active.
+            </div>
+          ) : (
+            <MessageInput
+              pseudonym={pseudonym}
+              enhancers={enhancers}
+              onSendMessage={onSendMessage}
+              waitingForResponse={waitingForResponse}
+              controlledMode={controlledMode}
+              onExitControlledMode={onExitControlledMode}
+              inputValue={inputValue}
+              onInputChange={onInputChange}
+            />
+          )}
         </div>
       </div>
 

--- a/components/GroupChatPanel.tsx
+++ b/components/GroupChatPanel.tsx
@@ -84,7 +84,6 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
   );
 
   // Extract unique contributors for mentions
-  // Normalize "Event Assistant Plus" and "Mediators" to "Event Assistant" for consistency
   const contributors = useMemo(
     () =>
       Array.from(

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -370,10 +370,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         // Check if the event has an event assistant agent
         const eventAsstAgent = conversation.agents.find(
           (agent: components["schemas"]["Agent"]) =>
-            agent.agentType === "eventAssistant" ||
-            agent.agentType === "eventAssistantPlus" ||
-            agent.agentType === "eventChannelMediator" ||
-            agent.agentType === "eventChannelMediatorPlus",
+            agent.agentType === "eventAssistant",
         );
         if (eventAsstAgent) {
           setAgentId(eventAsstAgent.id!);

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -130,6 +130,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     PseudonymousMessage[]
   >([]);
   const [agentId, setAgentId] = useState<string | null>(null);
+  const [agentActive, setAgentActive] = useState<boolean>(true);
   const [jargonFilterAgentId, setJargonFilterAgentId] = useState<string | null>(
     null,
   );
@@ -397,10 +398,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         if (eventAsstAgent) {
           setAgentId(eventAsstAgent.id!);
         } else {
-          setLocalError(
-            "This conversation does not have an event assistant agent.",
-          );
-          return;
+          setAgentActive(false);
         }
 
         const jargonAgent = conversation.agents.find(
@@ -422,26 +420,34 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   // Also re-joins automatically on every socket reconnection so that messages
   // continue flowing after a token refresh or transient network drop.
   useEffect(() => {
-    if (!socket || !agentId || !userId || !router.query.conversationId) {
+    if (!socket || !userId || !router.query.conversationId) {
+      return;
+    }
+
+    // Only wait for agentId if the agent is expected to be active
+    if (agentActive && !agentId) {
       return;
     }
 
     // Build direct channels based on available agents and user preferences
-    const agentChannels = buildDirectChannels(
-      userId,
-      [
-        { agentId },
-        ...(jargonFilterAgentId
-          ? [
-              {
-                agentId: jargonFilterAgentId,
-                preferenceKey: "jargonClarification",
-              },
-            ]
-          : []),
-      ],
-      userPreferences,
-    );
+    const agentChannels =
+      agentId
+        ? buildDirectChannels(
+            userId,
+            [
+              { agentId },
+              ...(jargonFilterAgentId
+                ? [
+                    {
+                      agentId: jargonFilterAgentId,
+                      preferenceKey: "jargonClarification",
+                    },
+                  ]
+                : []),
+            ],
+            userPreferences,
+          )
+        : [];
 
     const channels: components["schemas"]["Channel"][] = [...agentChannels];
     if (chatPasscode) {
@@ -457,6 +463,12 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         passcode: resourcesPasscode,
         direct: false,
       });
+    }
+
+    // Nothing to join if there are no channels (e.g. inactive event with no agent
+    // and no chat/resources passcodes — transcript uses its own channel:join).
+    if (channels.length === 0) {
+      return;
     }
 
     const joinConversation = () => {
@@ -488,6 +500,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   }, [
     socket,
     agentId,
+    agentActive,
     jargonFilterAgentId,
     userId,
     userPreferences,
@@ -1107,6 +1120,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
                           onPreferencesSubmit={handlePreferencesSubmit}
                           preferencesError={preferencesError}
                           feedbackConfig={assistantFeedbackConfig}
+                          inactive={!agentActive}
                           messagesWithUnreadReplies={
                             assistantMessagesWithUnreadReplies
                           }

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -105,11 +105,15 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [unseenAssistantCount, setUnseenAssistantCount] = useState<number>(0);
   const [unseenChatCount, setUnseenChatCount] = useState<number>(0);
   const [unseenResourcesCount, setUnseenResourcesCount] = useState<number>(0);
-  const [resourcesNavBadgeDismissed, setResourcesNavBadgeDismissed] = useState(false);
-  const [unreadAssistantReplyCount, setUnreadAssistantReplyCount] = useState<number>(0);
+  const [resourcesNavBadgeDismissed, setResourcesNavBadgeDismissed] =
+    useState(false);
+  const [unreadAssistantReplyCount, setUnreadAssistantReplyCount] =
+    useState<number>(0);
   const [unreadChatReplyCount, setUnreadChatReplyCount] = useState<number>(0);
   // Track which resource message IDs contain new (unseen) readings for highlighting
-  const [newReadingMessageIds, setNewReadingMessageIds] = useState<Set<string>>(new Set());
+  const [newReadingMessageIds, setNewReadingMessageIds] = useState<Set<string>>(
+    new Set(),
+  );
 
   // Track previous reply counts for chat messages (persists across tab switches)
   const [chatPreviousReplyCounts, setChatPreviousReplyCounts] = useState<
@@ -122,7 +126,9 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     PseudonymousMessage[]
   >([]);
   const [chatMessages, setChatMessages] = useState<PseudonymousMessage[]>([]);
-  const [resourcesMessages, setResourcesMessages] = useState<PseudonymousMessage[]>([]);
+  const [resourcesMessages, setResourcesMessages] = useState<
+    PseudonymousMessage[]
+  >([]);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [jargonFilterAgentId, setJargonFilterAgentId] = useState<string | null>(
     null,
@@ -130,6 +136,9 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [userPreferences, setUserPreferences] = useState<
     Record<string, boolean>
   >({});
+  const [conversationFeatures, setConversationFeatures] = useState<
+    { name: string; enabled?: boolean }[]
+  >([]);
   const conversationType = useConversationType();
   const setConversationType = useSetConversationType();
   const setBotNameContext = useSetBotName();
@@ -151,8 +160,12 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [resourcesPasscode, setResourcesPasscode] = useState<string>("");
   const [eventName, setEventName] = useState<string>("");
   const [eventDescription, setEventDescription] = useState<string>("");
-  const [speakers, setSpeakers] = useState<Array<{ name: string; bio: string }>>([]);
-  const [moderators, setModerators] = useState<Array<{ name: string; bio: string }>>([]);
+  const [speakers, setSpeakers] = useState<
+    Array<{ name: string; bio: string }>
+  >([]);
+  const [moderators, setModerators] = useState<
+    Array<{ name: string; bio: string }>
+  >([]);
   const [botName, setBotName] = useState<string>("Berkie");
   const [assistantInputValue, setAssistantInputValue] = useState<string>("");
   const [chatInputValue, setChatInputValue] = useState<string>("");
@@ -200,7 +213,11 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   // Derive slash commands from the loaded conversation type's features.
   // Empty until the type loads, so the autocomplete stays hidden during that window.
   const slashCommands: SlashCommand[] = (conversationType?.features ?? [])
-    .filter((f) => f.slashCommand != null)
+    .filter((f) => {
+      if (f.slashCommand == null) return false;
+      const override = conversationFeatures.find((cf) => cf.name === f.name);
+      return override?.enabled !== false;
+    })
     .map((f) => ({
       command: f.slashCommand!,
       description: f.description ?? "",
@@ -308,6 +325,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
 
         const conversation = await createConversationFromData(conversationData);
         setConversationType(conversation.type);
+        setConversationFeatures(conversation.features ?? []);
         if (conversation.name) setEventName(conversation.name);
 
         // Extract event metadata from conversation
@@ -319,10 +337,14 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
           setEventDescription(conversation.description as string);
         }
         if (conversation?.presenters) {
-          setSpeakers(conversation.presenters as Array<{ name: string; bio: string }>);
+          setSpeakers(
+            conversation.presenters as Array<{ name: string; bio: string }>,
+          );
         }
         if (conversation?.moderators) {
-          setModerators(conversation.moderators as Array<{ name: string; bio: string }>);
+          setModerators(
+            conversation.moderators as Array<{ name: string; bio: string }>,
+          );
         }
 
         // Override botName from the first agent's agentConfig if available,
@@ -715,11 +737,19 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         .then((msgs) => {
           if (Array.isArray(msgs)) setResourcesMessages(msgs);
         })
-        .catch((err) => console.error("Error re-fetching resources messages:", err));
+        .catch((err) =>
+          console.error("Error re-fetching resources messages:", err),
+        );
     }
 
     fetchAllAssistantMessages();
-  }, [lastReconnectTime, router.query.conversationId, chatPasscode, resourcesPasscode, fetchAllAssistantMessages]);
+  }, [
+    lastReconnectTime,
+    router.query.conversationId,
+    chatPasscode,
+    resourcesPasscode,
+    fetchAllAssistantMessages,
+  ]);
 
   async function sendMessage(
     message: string,
@@ -987,7 +1017,9 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
               onTabChange={handleTabChange}
               unseenAssistantCount={unseenAssistantCount}
               unseenChatCount={unseenChatCount}
-              unseenResourcesCount={resourcesNavBadgeDismissed ? 0 : unseenResourcesCount}
+              unseenResourcesCount={
+                resourcesNavBadgeDismissed ? 0 : unseenResourcesCount
+              }
               unreadAssistantReplyCount={unreadAssistantReplyCount}
               unreadChatReplyCount={unreadChatReplyCount}
               showChat={!!chatPasscode}

--- a/pages/guide/[conversationId].tsx
+++ b/pages/guide/[conversationId].tsx
@@ -278,6 +278,49 @@ function FeatureRowWithPill({ f }: { f: FeatureConfig }) {
   );
 }
 
+function SlashCommandRow({ f }: { f: FeatureConfig }) {
+  const state: PillState = f.enabled === false ? "unavailable" : "active";
+  const isUnavailable = state === "unavailable";
+  const descColor = isUnavailable ? "text.disabled" : "text.secondary";
+  return (
+    <Box
+      aria-disabled={isUnavailable ? "true" : undefined}
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "110px 1fr auto", sm: "160px 1fr auto" },
+        gap: 2,
+        py: 1,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        "&:last-child": { borderBottom: "none" },
+        alignItems: "start",
+        opacity: isUnavailable ? 0.6 : 1,
+      }}
+    >
+      <Box>
+        <Typography
+          variant="body2"
+          sx={{
+            fontFamily: "monospace",
+            bgcolor: isUnavailable ? "transparent" : "action.hover",
+            display: "inline-block",
+            px: 0.75,
+            py: 0.25,
+            borderRadius: 1,
+            color: isUnavailable ? "text.disabled" : "text.primary",
+          }}
+        >
+          /{f.slashCommand}
+        </Typography>
+      </Box>
+      <Typography variant="body2" color={descColor}>
+        {f.description}
+      </Typography>
+      <StatusPill state={state} />
+    </Box>
+  );
+}
+
 function TabSection({
   tab,
   features,
@@ -300,9 +343,7 @@ function TabSection({
   const automatic = features.filter(
     (f) => !f.slashCommand && !f.userControlled,
   );
-  const hasDisabled = features.some(
-    (f) => !f.slashCommand && f.enabled === false,
-  );
+  const hasDisabled = features.some((f) => f.enabled === false);
   const hasNonSlash = userControlled.length + automatic.length > 0;
 
   return (
@@ -379,46 +420,16 @@ function TabSection({
         {/* Slash commands — header with Active pill, existing table below */}
         {slashCommands.length > 0 && (
           <Box sx={{ pt: 1.5, pb: hasNonSlash ? 0 : 1.5 }}>
-            <Box
-              sx={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                mb: 1,
-              }}
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ ...TIER_LABEL_SX, mb: 1 }}
             >
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={TIER_LABEL_SX}
-              >
-                Commands — type / in the chat
-              </Typography>
-              <StatusPill state="active" />
-            </Box>
+              Commands — type / in the chat
+            </Typography>
             <Box sx={{ pl: 2 }}>
               {slashCommands.map((f) => (
-                <FeatureRow
-                  key={f.name}
-                  f={f}
-                  nameSlot={
-                    <Box>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          fontFamily: "monospace",
-                          bgcolor: "action.hover",
-                          display: "inline-block",
-                          px: 0.75,
-                          py: 0.25,
-                          borderRadius: 1,
-                        }}
-                      >
-                        /{f.slashCommand}
-                      </Typography>
-                    </Box>
-                  }
-                />
+                <SlashCommandRow key={f.name} f={f} />
               ))}
             </Box>
           </Box>

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -298,7 +298,7 @@ async function getTypeForConversation(
       (type) => type.name === conversation.conversationType,
     );
     if (type) return type;
-    // backwards compatibility for removed conversation types like eventAssistantPlusProactive
+    // backwards compatibility for removed conversation types
     return {
       name: conversation.conversationType,
       description: "",
@@ -351,6 +351,11 @@ function generateEventUrls(
     (channel) => channel.name === "moderator",
   )?.passcode;
 
+  const moderatorFeatureEnabled =
+    conversationData.features?.some(
+      (f) => f.name === "moderatorSupport" && f.enabled === true,
+    ) ?? false;
+
   const modUrl = modPasscode
     ? `${urlPrefix}/moderator/?conversationId=${
         conversationData.id
@@ -370,7 +375,7 @@ function generateEventUrls(
         url: `${urlPrefix}/backchannel/?conversationId=${conversationData.id}&channel=participant,${participantPasscode}`,
       });
     }
-    if (modPasscode) {
+    if (moderatorFeatureEnabled && modPasscode) {
       moderator.push({
         label: "Back Channel",
         url: modUrl,
@@ -386,27 +391,9 @@ function generateEventUrls(
       }`,
     };
     participant.push(eventAssistantUrl);
-  } else if (
-    convType &&
-    (convType.name === "eventAssistantPlus" ||
-      convType.name === "eventAssistantPlusProactive")
-  ) {
-    const label =
-      convType.name === "eventAssistantPlus"
-        ? `${botName} Plus`
-        : `${botName} Plus Proactive`;
-    const eventAssistantPlusUrl = {
-      label,
-      url: `${urlPrefix}/assistant/?conversationId=${conversationData.id}${
-        hasTranscript ? `&channel=transcript,${transcriptPasscode}` : ""
-      }${hasChat ? `&channel=chat,${chatPasscode}` : ""}${
-        hasResources ? `&channel=resources,${resourcesPasscode}` : ""
-      }`,
-    };
-    participant.push(eventAssistantPlusUrl);
-    if (modPasscode) {
+    if (moderatorFeatureEnabled && modPasscode) {
       moderator.push({
-        label,
+        label: botName,
         url: modUrl,
       });
     }

--- a/utils/eventReportGenerator.ts
+++ b/utils/eventReportGenerator.ts
@@ -245,7 +245,7 @@ async function fetchUserMetricsReport(
       reportName: "userMetrics",
       format: "csv",
       additionalChannels: "chat",
-      agent: "eventAssistantPlus",
+      agent: "eventAssistant",
     });
 
     const urlSuffix = `conversations/${conversationId}/report?${params.toString()}`;

--- a/utils/feedbackEligibility.ts
+++ b/utils/feedbackEligibility.ts
@@ -6,7 +6,6 @@ import { parseMessageBody } from "./Helpers";
  */
 export const INELIGIBLE_MESSAGE_TYPES = [
   "intro",
-  "unanswerable",
   "moderator_offered",
   "moderator_submitted",
   "moderator_declined",
@@ -23,7 +22,7 @@ export const INELIGIBLE_MESSAGE_TYPES = [
  */
 export function getFeedbackEligibleMessages(
   messages: PseudonymousMessage[],
-  feedbackFrequency: number = 1
+  feedbackFrequency: number = 1,
 ): Set<string> {
   // If frequency is 0 or negative, never show feedback
   if (feedbackFrequency <= 0) {


### PR DESCRIPTION
## What is in this PR?

Removes support for old `eventAssistantPlus` conversation type and builds slash command menu and documentation to exclude slash commands from disabled features.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- feat: remove refs to eventAssistantPlus conv type and build moderator URL only when feature enabled
- feat: only include slash commands from enabled features in menu and guide
- feat: allow feedback on unanswerable messages (unrelated to this - Johnny just made a change to make answers to these qs more interesting, so feedback collection seems warranted)
- feat: allow display of assistant page for past events with invalid agents - flag that Berkie is unavailable in this case, but allow users to display the page to see transcript and group chat messages

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Test in conjunction with https://github.com/berkmancenter/llm_engine/pull/106 See steps there



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
