### PR TITLE
feat: add alternate name input for speakers and moderators

### DIFF
--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -11,6 +11,8 @@ import { RetrieveData, Request } from "../../utils";
 import { Api } from "../../utils/Helpers";
 import "@testing-library/jest-dom";
 
+jest.setTimeout(60000);
+
 // Mock next/router
 const mockPush = jest.fn();
 jest.mock("next/router", () => ({

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -984,7 +984,7 @@ describe("EventCreationForm Component", () => {
     await waitFor(() => screen.getByText("About the Speakers"));
 
     // Add speaker info
-    const speakerNameInputs = screen.getAllByLabelText(/Name/i);
+    const speakerNameInputs = screen.getAllByLabelText(/^Name$/i);
     await user.type(speakerNameInputs[0], "John Doe");
     const speakerBioInputs = screen.getAllByLabelText(/Bio/i);
     await user.type(speakerBioInputs[0], "Expert speaker");
@@ -999,7 +999,7 @@ describe("EventCreationForm Component", () => {
       expect(screen.getByText("Moderator 1")).toBeInTheDocument();
     });
 
-    const moderatorNameInput = screen.getAllByLabelText(/Name/i)[1];
+    const moderatorNameInput = screen.getAllByLabelText(/^Name$/i)[1];
     await user.type(moderatorNameInput, "Jane Smith");
     const moderatorBioInput = screen.getAllByLabelText(/Bio/i)[1];
     await user.type(moderatorBioInput, "Experienced moderator");
@@ -1869,6 +1869,105 @@ describe("EventCreationForm Component", () => {
         expect(Request).not.toHaveBeenCalledWith(
           "topics",
           expect.anything(),
+        );
+      });
+    });
+  });
+
+  describe("Alternate Name field", () => {
+    const navigateToStep4 = async (user: ReturnType<typeof userEvent.setup>) => {
+      await fillEventDetails(
+        "Test Event",
+        "https://huitstage.zoom.us/j/1234567890",
+      );
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => screen.getByText("Nextspace"));
+      await user.click(screen.getByRole("checkbox", { name: /zoom/i }));
+      await user.click(screen.getByRole("radio", { name: /back channel/i }));
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => screen.getByLabelText(/Bot Name/i));
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => screen.getByText("About the Speakers"));
+    };
+
+    beforeEach(() => {
+      (Request as jest.Mock).mockImplementation(
+        makeRequestMock({
+          id: "new-conv-altname",
+          name: "Test Event",
+          channels: [],
+          agents: [],
+          adapters: [],
+          conversationType: "eventAssistant",
+        }),
+      );
+    });
+
+    it("renders Alternate Name input for speakers", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep4(user);
+
+      expect(
+        screen.getByLabelText(/Alternate Name/i),
+      ).toBeInTheDocument();
+    });
+
+    it("renders Alternate Name input for moderators", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep4(user);
+
+      await user.click(
+        screen.getByRole("button", { name: /\+ Add Moderators/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Moderator 1")).toBeInTheDocument();
+      });
+
+      const alternateNameInputs = screen.getAllByLabelText(/Alternate Name/i);
+      expect(alternateNameInputs.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("includes alternateName in the request payload", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep4(user);
+
+      const nameInputs = screen.getAllByLabelText(/^Name$/i);
+      await user.type(nameInputs[0], "Jonathan Smith");
+
+      const alternateNameInput = screen.getByLabelText(/Alternate Name/i);
+      await user.type(alternateNameInput, "Jon");
+
+      await user.click(
+        screen.getByRole("button", { name: /create conversation/i }),
+      );
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          "conversations/from-type",
+          expect.objectContaining({
+            presenters: [
+              expect.objectContaining({
+                name: "Jonathan Smith",
+                alternateName: "Jon",
+              }),
+            ],
+          }),
         );
       });
     });

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -100,10 +100,10 @@ export const EventCreationForm: React.FC = ({}) => {
 
   // Moderators and Speakers state
   const [moderators, setModerators] = useState<
-    Array<{ name: string; bio: string }>
+    Array<{ name: string; bio: string; alternateName?: string }>
   >([{ name: "", bio: "" }]);
   const [speakers, setSpeakers] = useState<
-    Array<{ name: string; bio: string }>
+    Array<{ name: string; bio: string; alternateName?: string }>
   >([{ name: "", bio: "" }]);
   const [showModerators, setShowModerators] = useState<boolean>(false);
 
@@ -357,7 +357,7 @@ export const EventCreationForm: React.FC = ({}) => {
 
   const updateModerator = (
     index: number,
-    field: "name" | "bio",
+    field: "name" | "bio" | "alternateName",
     value: string,
   ) => {
     const updated = [...moderators];
@@ -378,7 +378,7 @@ export const EventCreationForm: React.FC = ({}) => {
 
   const updateSpeaker = (
     index: number,
-    field: "name" | "bio",
+    field: "name" | "bio" | "alternateName",
     value: string,
   ) => {
     const updated = [...speakers];
@@ -1485,6 +1485,25 @@ export const EventCreationForm: React.FC = ({}) => {
                     variant="outlined"
                     margin="normal"
                   />
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 1, mb: 0.5 }}
+                  >
+                    Attendees or the live transcription might use a nickname,
+                    abbreviation, or misspelling. Adding it here helps the
+                    platform connect those references to the right person.
+                  </Typography>
+                  <TextField
+                    label="Alternate Name"
+                    value={speaker.alternateName ?? ""}
+                    onChange={(e) =>
+                      updateSpeaker(index, "alternateName", e.target.value)
+                    }
+                    fullWidth
+                    variant="outlined"
+                    placeholder="Separate multiple names with commas, e.g. Jon, Dr. Smith"
+                  />
                   <TextField
                     label="Bio"
                     value={speaker.bio}
@@ -1590,6 +1609,30 @@ export const EventCreationForm: React.FC = ({}) => {
                           variant="outlined"
                           margin="normal"
                           placeholder="Enter moderator's name"
+                        />
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ mt: 1, mb: 0.5 }}
+                        >
+                          Attendees or the live transcription might use a
+                          nickname, abbreviation, or misspelling. Adding it
+                          here helps the platform connect those references to
+                          the right person.
+                        </Typography>
+                        <TextField
+                          label="Alternate Name"
+                          value={moderator.alternateName ?? ""}
+                          onChange={(e) =>
+                            updateModerator(
+                              index,
+                              "alternateName",
+                              e.target.value,
+                            )
+                          }
+                          fullWidth
+                          variant="outlined"
+                          placeholder="Separate multiple names with commas, e.g. Jon, Dr. Smith"
                         />
                         <TextField
                           label="Bio"


### PR DESCRIPTION
## What is in this PR?
Adds an "Alternate Name" input to the speaker and moderator sections of the event creation form. Pairs with the llm_engine PR.

## Changes in the codebase
- Added "Alternate Name" field to speaker and moderator entries in step 4 of the event creation form

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR
- [ ] Navigate to step 4 of the event creation form
- [ ] Confirm the "Alternate Name" field appears under each speaker and moderator entry with helper text and placeholder
- [ ] Submit the form and confirm `alternateName` is included in the request payload

## Additional information
Pairs with [llm_engine #109](https://github.com/berkmancenter/llm_engine/pull/109).