### PR TITLE
feat: add event end time to event creation form

### DIFF
--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -118,6 +118,10 @@ const fillEventDetails = async (name: string, zoomUrl: string) => {
 
   // Assert the input value
   expect(dateInput).toHaveTextContent("11/15/2025 10:00 AMMeeting Day/Time");
+
+  // Set end time (required when start time is provided)
+  const endTimeInput = screen.getAllByLabelText(/Meeting End Time/i)[0];
+  await user.type(endTimeInput, "11/15/2025 11:00 AM");
 };
 
 const mockConfig = {
@@ -1553,6 +1557,167 @@ describe("EventCreationForm Component", () => {
       await waitFor(() => screen.getByLabelText(/Bot Name/i));
 
       expect(screen.queryByText("Features")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Scheduled Times", () => {
+    it("shows error when start time is provided but end time is missing", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      // Fill required fields with a start time but no end time
+      await user.type(screen.getByLabelText(/Event Name/i), "Test Event");
+
+      const topicInput = screen.getByLabelText(/Select a series/i);
+      fireEvent.click(topicInput);
+      fireEvent.keyDown(topicInput, { key: "ArrowDown" });
+      fireEvent.click(
+        await screen.findByRole("option", { name: /Public Topic 1/i }),
+      );
+
+      await user.type(
+        screen.getByLabelText(/Zoom Meeting URL/i),
+        "https://huitstage.zoom.us/j/1234567890",
+      );
+
+      const startTimeInput = screen.getAllByLabelText(/Meeting Day\/Time/i)[0];
+      await user.type(startTimeInput, "11/15/2025 10:00 AM");
+
+      // No end time set
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Meeting End Time is required when a start time is provided",
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows error when end time is provided but start time is missing", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      // Fill required fields without setting start time
+      const nameInput = screen.getByLabelText(/Event Name/i);
+      await user.type(nameInput, "Test Event");
+
+      const topicInput = screen.getByLabelText(/Select a series/i);
+      fireEvent.click(topicInput);
+      fireEvent.keyDown(topicInput, { key: "ArrowDown" });
+      const topicOption = await screen.findByRole("option", {
+        name: /Public Topic 1/i,
+      });
+      fireEvent.click(topicOption);
+
+      const urlInput = screen.getByLabelText(/Zoom Meeting URL/i);
+      await user.type(urlInput, "https://huitstage.zoom.us/j/1234567890");
+
+      // Set only end time, no start time
+      const endTimeInput = screen.getAllByLabelText(/Meeting End Time/i)[0];
+      await user.type(endTimeInput, "11/15/2025 11:00 AM");
+
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Meeting Start Time is required when an end time is provided",
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows inline error when end time is before start time", async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      // Set start time to 10:00 AM
+      const startTimeInput = screen.getAllByLabelText(/Meeting Day\/Time/i)[0];
+      await user.type(startTimeInput, "11/15/2025 10:00 AM");
+
+      // Set end time to 09:00 AM (before start)
+      const endTimeInput = screen.getAllByLabelText(/Meeting End Time/i)[0];
+      await user.type(endTimeInput, "11/15/2025 09:00 AM");
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Meeting End Time must be after the start time."),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("includes scheduledEndTime in payload when both times are provided", async () => {
+      const user = userEvent.setup();
+      const mockConversationData = {
+        id: "new-conv-times",
+        name: "Timed Event",
+        channels: [],
+        agents: [],
+        adapters: [],
+        conversationType: "backChannel",
+      };
+      (Request as jest.Mock).mockImplementation(
+        makeRequestMock(mockConversationData),
+      );
+
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      // Fill name and topic
+      await user.type(screen.getByLabelText(/Event Name/i), "Timed Event");
+
+      const topicInput = screen.getByLabelText(/Select a series/i);
+      fireEvent.click(topicInput);
+      fireEvent.keyDown(topicInput, { key: "ArrowDown" });
+      fireEvent.click(
+        await screen.findByRole("option", { name: /Public Topic 1/i }),
+      );
+
+      await user.type(
+        screen.getByLabelText(/Zoom Meeting URL/i),
+        "https://huitstage.zoom.us/j/1234567890",
+      );
+
+      // Set start and end times
+      const startTimeInput = screen.getAllByLabelText(/Meeting Day\/Time/i)[0];
+      await user.type(startTimeInput, "11/15/2025 10:00 AM");
+
+      const endTimeInput = screen.getAllByLabelText(/Meeting End Time/i)[0];
+      await user.type(endTimeInput, "11/15/2025 11:00 AM");
+
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => screen.getByText("Nextspace"));
+      await user.click(screen.getByRole("checkbox", { name: /zoom/i }));
+      await user.click(screen.getByRole("radio", { name: /back channel/i }));
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => screen.getByLabelText(/Bot Name/i));
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      await waitFor(() => screen.getByText("About the Speakers"));
+      await user.click(
+        screen.getByRole("button", { name: /create conversation/i }),
+      );
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          "conversations/from-type",
+          expect.objectContaining({
+            scheduledTime: expect.any(String),
+            scheduledEndTime: expect.any(String),
+          }),
+        );
+      });
     });
   });
 

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -81,6 +81,11 @@ export const EventCreationForm: React.FC = ({}) => {
   const [zoomMeetingUrlHasError, setZoomMeetingUrlHasError] =
     useState<boolean>(false);
   const [zoomMeetingTime, setZoomMeetingTime] = useState<string>("");
+  const [scheduledEndTime, setScheduledEndTime] = useState<string>("");
+  const [scheduledEndTimeHasError, setScheduledEndTimeHasError] =
+    useState<boolean>(false);
+  const [zoomMeetingTimeHasError, setZoomMeetingTimeHasError] =
+    useState<boolean>(false);
 
   const [dynamicPropertyValues, setDynamicPropertyValues] = useState<
     Record<string, any>
@@ -299,6 +304,21 @@ export const EventCreationForm: React.FC = ({}) => {
     if (!zoomMeetingUrl) {
       setFormError("Zoom Meeting URL is required");
       setFieldFocus("zoomMeetingUrl");
+      return false;
+    }
+
+    if (scheduledEndTime && !zoomMeetingTime) {
+      setFormError("Meeting Start Time is required when an end time is provided");
+      return false;
+    }
+
+    if (zoomMeetingTime && !scheduledEndTime) {
+      setFormError("Meeting End Time is required when a start time is provided");
+      return false;
+    }
+
+    if (zoomMeetingTime && scheduledEndTime && scheduledEndTime <= zoomMeetingTime) {
+      setFormError("Meeting End Time must be after the start time");
       return false;
     }
 
@@ -854,6 +874,7 @@ export const EventCreationForm: React.FC = ({}) => {
       name: eventName,
       ...(eventDescription && { description: eventDescription }),
       ...(zoomMeetingTime && { scheduledTime: zoomMeetingTime }),
+      ...(scheduledEndTime && { scheduledEndTime }),
       platforms: selectedPlatforms,
       type: selectedConvType,
       topicId,
@@ -1189,17 +1210,45 @@ export const EventCreationForm: React.FC = ({}) => {
               <LocalizationProvider dateAdapter={AdapterDayjs}>
                 <DateTimePicker
                   label="Meeting Day/Time"
-                  onChange={(newValue) =>
-                    setZoomMeetingTime(
-                      newValue?.isValid() ? newValue?.toISOString() : "",
-                    )
-                  }
+                  onChange={(newValue) => {
+                    const value = newValue?.isValid() ? newValue.toISOString() : "";
+                    setZoomMeetingTime(value);
+                    setZoomMeetingTimeHasError(!value && !!scheduledEndTime);
+                    if (scheduledEndTime) {
+                      setScheduledEndTimeHasError(
+                        !!value && scheduledEndTime <= value,
+                      );
+                    }
+                  }}
                   slotProps={{
                     textField: {
                       margin: "normal",
                       fullWidth: true,
-                      helperText:
-                        "Enter the meeting start time if it begins more than 15 minutes from now.",
+                      error: zoomMeetingTimeHasError,
+                      helperText: zoomMeetingTimeHasError
+                        ? "Meeting Start Time is required when an end time is provided."
+                        : "Enter the meeting start time if it begins more than 15 minutes from now.",
+                    },
+                  }}
+                />
+                <DateTimePicker
+                  label="Meeting End Time"
+                  onChange={(newValue) => {
+                    const value = newValue?.isValid() ? newValue.toISOString() : "";
+                    setScheduledEndTime(value);
+                    setScheduledEndTimeHasError(
+                      !!value && !!zoomMeetingTime && value <= zoomMeetingTime,
+                    );
+                    setZoomMeetingTimeHasError(!value ? false : !zoomMeetingTime);
+                  }}
+                  slotProps={{
+                    textField: {
+                      margin: "normal",
+                      fullWidth: true,
+                      error: scheduledEndTimeHasError,
+                      helperText: scheduledEndTimeHasError
+                        ? "Meeting End Time must be after the start time."
+                        : "Enter the scheduled end time for the meeting (optional).",
                     },
                   }}
                 />


### PR DESCRIPTION
## What is in this PR?

Adds a scheduled end time field to the Event Creation Form to allow auto-stop of scheduled conversations. Especially important for Zoom meetings hosted in organizations that do not have a Zoom app set up to send 'meeting stopped' events to our conversation-stopping hook.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- Added a field and some error handling to ensure that start and end time are either both there or both absent (to start the conversation right away)

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [ ] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Test in conjunction with https://github.com/berkmancenter/llm_engine/pull/115. Some test steps there, but can also do these for error handling validation
- [x] try to specify start time w/out end time and vice versa
- [x] try to put end time before start time
- [x] Anything else you can think of to trick it :)



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
