### PR TITLE
refactor: retrieve intro messages in conversation/channel join callback instead of msg fetch

### DIFF
--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -2441,6 +2441,416 @@ describe("EventAssistantRoom", () => {
     });
   });
 
+  describe("Intro messages from conversation:join callback", () => {
+    it("displays assistant intro messages returned in the join callback response", async () => {
+      const introMessage = {
+        id: "intro-ws-1",
+        body: "Welcome to the event!",
+        pseudonym: "Berkie",
+        fromAgent: true,
+        channels: [],
+        createdAt: "2024-01-01T09:59:00Z",
+        conversation: "test-conversation-id",
+        pause: false,
+        visible: true,
+        upVotes: [],
+        downVotes: [],
+      };
+
+      const { emitWithTokenRefresh } = require("../../utils");
+      (emitWithTokenRefresh as jest.Mock).mockImplementationOnce(
+        (socket: any, event: string, data: any, onSuccess: Function) => {
+          if (onSuccess) onSuccess({ intros: [introMessage] });
+          socket.emit(event, data);
+        },
+      );
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        }
+        return Promise.resolve([]);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      const user = userEvent.setup();
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() =>
+        expect(createConversationFromData).toHaveBeenCalled(),
+      );
+
+      // Switch to assistant tab to see the intro message
+      const assistantTab = screen.getAllByLabelText("Berkie")[0];
+      await user.click(assistantTab);
+
+      await waitFor(() => {
+        expect(screen.getByText("Welcome to the event!")).toBeInTheDocument();
+      });
+    });
+
+    it("routes chat intros from join callback to the chat panel", async () => {
+      mockRouter.query = {
+        conversationId: "test-conversation-id",
+        channel: "chat,chat-pass",
+      };
+
+      const chatIntro = {
+        id: "chat-intro-1",
+        body: "Welcome to the chat!",
+        pseudonym: "Berkie",
+        fromAgent: true,
+        channels: ["chat"],
+        createdAt: "2024-01-01T09:59:00Z",
+      };
+
+      const { emitWithTokenRefresh } = require("../../utils");
+      (emitWithTokenRefresh as jest.Mock).mockImplementationOnce(
+        (socket: any, event: string, data: any, onSuccess: Function) => {
+          if (onSuccess) onSuccess({ intros: [chatIntro] });
+          socket.emit(event, data);
+        },
+      );
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        }
+        return Promise.resolve([]);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      // Chat tab is active by default when chatPasscode is set
+      await waitFor(() => {
+        expect(screen.getByText("Welcome to the chat!")).toBeInTheDocument();
+      });
+    });
+
+    it("filters out intro-typed messages (object body) from the DB assistant fetch", async () => {
+      const dbMessages = [
+        {
+          id: "intro-db-1",
+          // Object body with type: "intro" — parseMessageBody will return type "intro"
+          body: { type: "intro", text: "Old intro from DB" },
+          pseudonym: "Berkie",
+          fromAgent: true,
+          channels: ["direct-user-123-agent-123"],
+          createdAt: "2024-01-01T09:59:00Z",
+        },
+        {
+          id: "msg-db-1",
+          body: "Regular message from DB",
+          pseudonym: "User",
+          fromAgent: false,
+          channels: ["direct-user-123-agent-123"],
+          createdAt: "2024-01-01T10:00:00Z",
+        },
+      ];
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        } else if (path.includes("?channel=direct-")) {
+          return Promise.resolve(dbMessages);
+        }
+        return Promise.resolve([]);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      const user = userEvent.setup();
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() => {
+        expect(RetrieveData).toHaveBeenCalledWith(
+          "messages/test-conversation-id?channel=direct-user-123-agent-123",
+          "mock-access-token",
+        );
+      });
+
+      // Switch to assistant tab to see what was rendered
+      const assistantTab = screen.getAllByLabelText("Berkie")[0];
+      await user.click(assistantTab);
+
+      // Regular message should be visible
+      await waitFor(() => {
+        expect(screen.getByText("Regular message from DB")).toBeInTheDocument();
+      });
+
+      // The intro-typed message should have been filtered out
+      expect(screen.queryByText("Old intro from DB")).not.toBeInTheDocument();
+    });
+
+    it("filters out intro-typed messages from the DB chat fetch", async () => {
+      mockRouter.query = {
+        conversationId: "test-conversation-id",
+        channel: "chat,chat-pass",
+      };
+
+      const chatDbMessages = [
+        {
+          id: "chat-intro-db-1",
+          body: { type: "intro", text: "Old chat intro" },
+          pseudonym: "Berkie",
+          fromAgent: true,
+          channels: ["chat"],
+          createdAt: "2024-01-01T09:59:00Z",
+        },
+        {
+          id: "chat-msg-1",
+          body: "Regular chat message",
+          pseudonym: "User",
+          fromAgent: false,
+          channels: ["chat"],
+          createdAt: "2024-01-01T10:00:00Z",
+        },
+      ];
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        } else if (path.includes("?channel=chat")) {
+          return Promise.resolve(chatDbMessages);
+        }
+        return Promise.resolve([]);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() => {
+        expect(RetrieveData).toHaveBeenCalledWith(
+          "messages/test-conversation-id?channel=chat,chat-pass",
+          "mock-access-token",
+        );
+      });
+
+      // Chat tab is active by default
+      await waitFor(() => {
+        expect(screen.getByText("Regular chat message")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Old chat intro")).not.toBeInTheDocument();
+    });
+
+    it("prepends join callback intros before DB messages in the assistant panel", async () => {
+      const introMessage = {
+        id: "intro-ws-1",
+        body: "Intro message",
+        pseudonym: "Berkie",
+        fromAgent: true,
+        channels: [],
+        createdAt: "2024-01-01T09:59:00Z",
+      };
+
+      const { emitWithTokenRefresh } = require("../../utils");
+      (emitWithTokenRefresh as jest.Mock).mockImplementationOnce(
+        (socket: any, event: string, data: any, onSuccess: Function) => {
+          if (onSuccess) onSuccess({ intros: [introMessage] });
+          socket.emit(event, data);
+        },
+      );
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        } else if (path.includes("?channel=direct-")) {
+          return Promise.resolve([
+            {
+              id: "msg-db-1",
+              body: "DB message after intro",
+              pseudonym: "Berkie",
+              fromAgent: true,
+              channels: ["direct-user-123-agent-123"],
+              createdAt: "2024-01-01T10:00:00Z",
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      const user = userEvent.setup();
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() =>
+        expect(createConversationFromData).toHaveBeenCalled(),
+      );
+
+      const assistantTab = screen.getAllByLabelText("Berkie")[0];
+      await user.click(assistantTab);
+
+      // Wait for both messages to render (both fromAgent: true → AssistantMessage mock)
+      await waitFor(() => {
+        const messages = screen.getAllByTestId("assistant-message");
+        expect(messages.length).toBeGreaterThanOrEqual(2);
+      });
+
+      const messages = screen.getAllByTestId("assistant-message");
+      const introIdx = messages.findIndex(
+        (el) => el.textContent?.includes("Intro message"),
+      );
+      const dbIdx = messages.findIndex(
+        (el) => el.textContent?.includes("DB message after intro"),
+      );
+      expect(introIdx).toBeGreaterThanOrEqual(0);
+      expect(dbIdx).toBeGreaterThanOrEqual(0);
+      expect(introIdx).toBeLessThan(dbIdx);
+    });
+
+    it("does not fetch messages before conversation:join callback fires", async () => {
+      const { emitWithTokenRefresh } = require("../../utils");
+      (emitWithTokenRefresh as jest.Mock).mockImplementationOnce(
+        (socket: any, event: string, data: any, _onSuccess: Function) => {
+          // Intentionally do NOT call onSuccess — simulates join in progress
+          socket.emit(event, data);
+        },
+      );
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        }
+        return Promise.resolve([]);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() =>
+        expect(createConversationFromData).toHaveBeenCalled(),
+      );
+
+      // Give async effects time to settle
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+
+      // Message fetch should NOT have been triggered because initialJoinComplete
+      // never flipped to true (join callback was not called)
+      const messageFetch = (RetrieveData as jest.Mock).mock.calls.find(
+        ([path]: [string]) => path.includes("?channel=direct-"),
+      );
+      expect(messageFetch).toBeUndefined();
+    });
+
+    it("does not re-add intros on socket reconnect", async () => {
+      const introMessage = {
+        id: "intro-1",
+        body: "Intro message",
+        pseudonym: "Berkie",
+        fromAgent: true,
+        channels: [],
+        createdAt: "2024-01-01T09:59:00Z",
+      };
+
+      const { emitWithTokenRefresh } = require("../../utils");
+      (emitWithTokenRefresh as jest.Mock)
+        .mockImplementationOnce(
+          (socket: any, event: string, data: any, onSuccess: Function) => {
+            if (onSuccess) onSuccess({ intros: [introMessage] });
+            socket.emit(event, data);
+          },
+        )
+        .mockImplementationOnce(
+          (socket: any, event: string, data: any, onSuccess: Function) => {
+            if (onSuccess) onSuccess({ intros: [introMessage] });
+            socket.emit(event, data);
+          },
+        );
+
+      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith("conversations/")) {
+          return Promise.resolve({
+            agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+          });
+        }
+        return Promise.resolve([]);
+      });
+      (createConversationFromData as jest.Mock).mockResolvedValue({
+        agents: [{ id: "agent-123", agentType: "eventAssistant" }],
+        type: { name: "eventAssistant" },
+      });
+
+      const user = userEvent.setup();
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={"guest"} />);
+      });
+
+      await waitFor(() =>
+        expect(createConversationFromData).toHaveBeenCalled(),
+      );
+
+      const assistantTab = screen.getAllByLabelText("Berkie")[0];
+      await user.click(assistantTab);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Intro message")).toHaveLength(1);
+      });
+
+      // Simulate socket reconnect by invoking the registered "connect" handler
+      const connectHandlerCall = mockSocket.on.mock.calls.find(
+        ([event]: [string]) => event === "connect",
+      );
+      const connectHandler = connectHandlerCall?.[1];
+      expect(connectHandler).toBeDefined();
+
+      await act(async () => {
+        connectHandler();
+      });
+
+      // Intro should still only appear once — not duplicated
+      expect(screen.getAllByText("Intro message")).toHaveLength(1);
+    });
+  });
+
   describe("Resources channel", () => {
     const resourcesSetup = async () => {
       mockRouter.query = {

--- a/components/AssistantChatPanel.tsx
+++ b/components/AssistantChatPanel.tsx
@@ -413,9 +413,10 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
 
             {parentMessages.map((message, i) => {
               const replies = threadMap.get(message.id!) || [];
-
               // Calculate if we should show timestamp
               const showTimestamp = (() => {
+                // Some messages, like intros, may not have createdAt - in that case, don't show timestamp
+                if (!message.createdAt) return false;
                 if (i === 0) return true;
                 const prevDate = new Date(parentMessages[i - 1].createdAt!);
                 const currDate = new Date(message.createdAt!);

--- a/components/GroupChatPanel.tsx
+++ b/components/GroupChatPanel.tsx
@@ -332,6 +332,8 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
               {parentMessages.map((message, i) => {
                 // Determine if we should show timestamp
                 const showTimestamp = (() => {
+                  // Some messages, like intros, may not have createdAt - in that case, don't show timestamp
+                  if (!message.createdAt) return false;
                   if (i === 0) return true;
                   const prevDate = new Date(parentMessages[i - 1].createdAt!);
                   const currDate = new Date(message.createdAt!);

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -129,6 +129,13 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [resourcesMessages, setResourcesMessages] = useState<
     PseudonymousMessage[]
   >([]);
+  // Tracks whether the first conversation:join has completed so initial message
+  // fetches wait until intros (returned in the join callback) are applied first.
+  const [initialJoinComplete, setInitialJoinComplete] = useState(false);
+  // Refs hold the most-recent intro messages per channel so fetch effects and
+  // reconnect re-fetches can always prepend them without stale-closure issues.
+  const chatIntroRef = useRef<PseudonymousMessage[]>([]);
+  const assistantIntroRef = useRef<PseudonymousMessage[]>([]);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [agentActive, setAgentActive] = useState<boolean>(true);
   const [jargonFilterAgentId, setJargonFilterAgentId] = useState<string | null>(
@@ -430,24 +437,23 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     }
 
     // Build direct channels based on available agents and user preferences
-    const agentChannels =
-      agentId
-        ? buildDirectChannels(
-            userId,
-            [
-              { agentId },
-              ...(jargonFilterAgentId
-                ? [
-                    {
-                      agentId: jargonFilterAgentId,
-                      preferenceKey: "jargonClarification",
-                    },
-                  ]
-                : []),
-            ],
-            userPreferences,
-          )
-        : [];
+    const agentChannels = agentId
+      ? buildDirectChannels(
+          userId,
+          [
+            { agentId },
+            ...(jargonFilterAgentId
+              ? [
+                  {
+                    agentId: jargonFilterAgentId,
+                    preferenceKey: "jargonClarification",
+                  },
+                ]
+              : []),
+          ],
+          userPreferences,
+        )
+      : [];
 
     const channels: components["schemas"]["Channel"][] = [...agentChannels];
     if (chatPasscode) {
@@ -483,8 +489,38 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
           token: Api.get().getAccessToken(),
           channels,
         },
-        () => console.log("Successfully joined conversation"),
-        (error) => console.error("Failed to join conversation:", error),
+        (response) => {
+          console.log("Successfully joined conversation");
+
+          const intros: PseudonymousMessage[] = response?.intros ?? [];
+
+          chatIntroRef.current = intros.filter(
+            (m) => Array.isArray(m.channels) && m.channels.includes("chat"),
+          );
+          // Any intro not in chat belongs to the direct (assistant) channel.
+          assistantIntroRef.current = intros.filter(
+            (m) => !Array.isArray(m.channels) || !m.channels.includes("chat"),
+          );
+
+          // Only push intros into state on the very first join. Re-joins
+          // (e.g. when userPreferences loads and the effect re-runs) must not
+          // add them again — the initial fetch effects will prepend from the
+          // refs once initialJoinComplete flips to true.
+          setInitialJoinComplete((already) => {
+            if (!already) {
+              if (chatIntroRef.current.length > 0)
+                setChatMessages(chatIntroRef.current);
+              if (assistantIntroRef.current.length > 0)
+                setAssistantMessages(assistantIntroRef.current);
+            }
+            return true;
+          });
+        },
+        (error) => {
+          console.error("Failed to join conversation:", error);
+          // Unblock initial fetches even when join fails so messages still load.
+          setInitialJoinComplete(true);
+        },
       );
     };
 
@@ -523,9 +559,10 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         Api.get().getAccessToken(),
       );
 
-      let allMessages = Array.isArray(assistantMessages)
-        ? assistantMessages
-        : [];
+      // Filter intro messages from older conversations where intros were persisted
+      let allMessages = (
+        Array.isArray(assistantMessages) ? assistantMessages : []
+      ).filter((m) => parseMessageBody(m.body)?.type !== "intro");
 
       // Fetch jargon filter agent's messages, if enabled
       if (jargonFilterAgentId) {
@@ -547,7 +584,10 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
 
       if (allMessages.length > 0) {
         const messagesWithReplies = await fetchAndInsertReplies(allMessages);
-        setAssistantMessages(messagesWithReplies);
+        setAssistantMessages([
+          ...assistantIntroRef.current,
+          ...messagesWithReplies,
+        ]);
       }
     } catch (error) {
       console.error("Error fetching assistant messages:", error);
@@ -633,9 +673,11 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     setUnreadAssistantReplyCount(updatedUnreadSet.size);
   }, [assistantMessages, pseudonym]);
 
-  // Load initial chat messages when chatPasscode becomes available
+  // Load initial chat messages after the conversation:join completes (so intros
+  // are already in state before DB messages are prepended).
   useEffect(() => {
-    if (!chatPasscode || !router.query.conversationId) return;
+    if (!chatPasscode || !router.query.conversationId || !initialJoinComplete)
+      return;
 
     const fetchInitialMessages = async () => {
       try {
@@ -645,8 +687,12 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         );
 
         if (Array.isArray(chatMessages)) {
-          const messagesWithReplies = await fetchAndInsertReplies(chatMessages);
-          setChatMessages(messagesWithReplies);
+          // Filter intro messages from older conversations where intros were persisted
+          const nonIntros = chatMessages.filter(
+            (m) => parseMessageBody(m.body)?.type !== "intro",
+          );
+          const messagesWithReplies = await fetchAndInsertReplies(nonIntros);
+          setChatMessages([...chatIntroRef.current, ...messagesWithReplies]);
         }
       } catch (error) {
         console.error("Error fetching initial chat messages:", error);
@@ -654,7 +700,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     };
 
     fetchInitialMessages();
-  }, [chatPasscode, router.query.conversationId]);
+  }, [chatPasscode, router.query.conversationId, initialJoinComplete]);
 
   // Load initial resources messages when resourcesPasscode becomes available
   useEffect(() => {
@@ -662,13 +708,13 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
 
     const fetchInitialMessages = async () => {
       try {
-        const resourcesMessages = await RetrieveData(
+        const fetchedMessages = await RetrieveData(
           `messages/${router.query.conversationId}?channel=resources,${resourcesPasscode}`,
           Api.get().getAccessToken(),
         );
 
-        if (Array.isArray(resourcesMessages)) {
-          setResourcesMessages(resourcesMessages);
+        if (Array.isArray(fetchedMessages)) {
+          setResourcesMessages(fetchedMessages);
         }
       } catch (error) {
         console.error("Error fetching initial resources messages:", error);
@@ -718,10 +764,12 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     fetchUserPreferences();
   }, [userId]);
 
-  // Load initial assistant messages when userId and agentId become available
+  // Load initial assistant messages after the conversation:join completes (so
+  // intros are already in state before DB messages are prepended).
   useEffect(() => {
+    if (!initialJoinComplete) return;
     fetchAllAssistantMessages();
-  }, [fetchAllAssistantMessages]);
+  }, [fetchAllAssistantMessages, initialJoinComplete]);
 
   // Re-fetch all message history when the socket reconnects after a significant
   // gap (user was on another tab/app for a while). Fills any messages missed
@@ -737,7 +785,13 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         Api.get().getAccessToken(),
       )
         .then((msgs) => {
-          if (Array.isArray(msgs)) setChatMessages(msgs);
+          // Filter intro messages from older conversations where intros were persisted
+          if (Array.isArray(msgs)) {
+            const nonIntros = msgs.filter(
+              (m) => parseMessageBody(m.body)?.type !== "intro",
+            );
+            setChatMessages([...chatIntroRef.current, ...nonIntros]);
+          }
         })
         .catch((err) => console.error("Error re-fetching chat messages:", err));
     }

--- a/utils/tokenRefresh.ts
+++ b/utils/tokenRefresh.ts
@@ -57,7 +57,7 @@ export async function emitWithTokenRefresh(
   socket: any,
   event: string,
   data: any,
-  onSuccess?: () => void,
+  onSuccess?: (response?: any) => void,
   onError?: (error: any) => void
 ) {
   // Ensure we have a fresh token before emitting.
@@ -113,7 +113,7 @@ export async function emitWithTokenRefresh(
           } else {
             if (onSuccess) {
               try {
-                onSuccess();
+                onSuccess(response);
               } catch (e) {
                 console.error("Error in onSuccess callback:", e);
               }
@@ -149,7 +149,7 @@ export async function emitWithTokenRefresh(
     } else {
       if (onSuccess) {
         try {
-          onSuccess();
+          onSuccess(response);
         } catch (e) {
           console.error("Error in onSuccess callback:", e);
         }


### PR DESCRIPTION
…



## What is in this PR?

Intro messages will now be provided as callbacks to websocket joins, refactor to retrieve from there

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Test in conjunction with https://github.com/berkmancenter/llm_engine/pull/118. See test steps there.



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
