### PR TITLE
refactor: retrieve resources as conversation property, separate ws event rather than messages

### DIFF
--- a/__tests__/components/ResourcesPanel.test.tsx
+++ b/__tests__/components/ResourcesPanel.test.tsx
@@ -1,73 +1,45 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ResourcesPanel } from '../../components/ResourcesPanel';
-import { PseudonymousMessage } from '../../types.internal';
+import { components } from '../../types';
 
-// Mock parseMessageBody from Helpers
-jest.mock('../../utils/Helpers', () => ({
-  parseMessageBody: jest.fn(),
-}));
+type Resource = components['schemas']['Resource'];
 
-import { parseMessageBody } from '../../utils/Helpers';
-const mockParseMessageBody = parseMessageBody as jest.Mock;
-
-function makeMessage(body: any): PseudonymousMessage {
-  return { id: 'msg-1', body } as unknown as PseudonymousMessage;
+function makeResource(overrides: Partial<Resource> = {}): Resource {
+  return {
+    id: 'res-1',
+    source: 'ai',
+    category: 'suggested',
+    title: 'The Internet and Democracy',
+    authors: ['Jane Doe', 'John Smith'],
+    year: '2021',
+    relevanceReason: "Directly relevant to today's discussion.",
+    participantVisible: true,
+    ...overrides,
+  };
 }
 
-const readingMessage = makeMessage({
-  type: 'reading',
-  content: [
-    {
-      title: 'The Internet and Democracy',
-      authors: ['Jane Doe', 'John Smith'],
-      year: 2021,
-      abstract: 'An abstract about internet and democracy.',
-      relevanceReason: "Directly relevant to today's discussion.",
-    },
-  ],
-});
-
-const readingMessageNoOptionals = makeMessage({
-  type: 'reading',
-  content: [
-    {
-      title: 'Digital Governance',
-      authors: ['Alice Wang'],
-      year: 2019,
-    },
-  ],
-});
-
 describe('ResourcesPanel', () => {
-  beforeEach(() => {
-    mockParseMessageBody.mockReturnValue({ text: '', type: undefined });
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('header / event info', () => {
     it('renders default title when eventName is not provided', () => {
-      render(<ResourcesPanel messages={[]} />);
+      render(<ResourcesPanel resources={[]} />);
       expect(screen.getByText('Event Resources')).toBeInTheDocument();
     });
 
     it('renders eventName when provided', () => {
-      render(<ResourcesPanel messages={[]} eventName="Tech & Society Forum" />);
+      render(<ResourcesPanel resources={[]} eventName="Tech & Society Forum" />);
       expect(screen.getByText('Tech & Society Forum')).toBeInTheDocument();
     });
 
     it('renders short eventDescription without truncation controls', () => {
-      render(<ResourcesPanel messages={[]} eventDescription="Short description." />);
+      render(<ResourcesPanel resources={[]} eventDescription="Short description." />);
       expect(screen.getByText('Short description.')).toBeInTheDocument();
       expect(screen.queryByText('more')).not.toBeInTheDocument();
     });
 
     it("truncates long eventDescription and shows 'more' button", () => {
       const longDescription = 'A'.repeat(600);
-      render(<ResourcesPanel messages={[]} eventDescription={longDescription} />);
+      render(<ResourcesPanel resources={[]} eventDescription={longDescription} />);
       expect(screen.getByText('more')).toBeInTheDocument();
       expect(screen.queryByText('less')).not.toBeInTheDocument();
     });
@@ -75,7 +47,7 @@ describe('ResourcesPanel', () => {
     it("expands truncated eventDescription on 'more' click and shows 'less'", async () => {
       const user = userEvent.setup();
       const longDescription = 'A'.repeat(600);
-      render(<ResourcesPanel messages={[]} eventDescription={longDescription} />);
+      render(<ResourcesPanel resources={[]} eventDescription={longDescription} />);
       await user.click(screen.getByText('more'));
       expect(screen.getByText('less')).toBeInTheDocument();
       expect(screen.queryByText('more')).not.toBeInTheDocument();
@@ -84,7 +56,7 @@ describe('ResourcesPanel', () => {
     it("collapses expanded description back on 'less' click", async () => {
       const user = userEvent.setup();
       const longDescription = 'B'.repeat(600);
-      render(<ResourcesPanel messages={[]} eventDescription={longDescription} />);
+      render(<ResourcesPanel resources={[]} eventDescription={longDescription} />);
       await user.click(screen.getByText('more'));
       await user.click(screen.getByText('less'));
       expect(screen.getByText('more')).toBeInTheDocument();
@@ -93,21 +65,20 @@ describe('ResourcesPanel', () => {
 
   describe('category headers', () => {
     it('renders Speakers and Readings & References category headers', () => {
-      render(<ResourcesPanel messages={[]} />);
+      render(<ResourcesPanel resources={[]} />);
       expect(screen.getByText('Speakers')).toBeInTheDocument();
       expect(screen.getByText('Readings & References')).toBeInTheDocument();
     });
 
     it('categories are collapsed by default (content not visible)', () => {
-      render(<ResourcesPanel messages={[]} speakers={[{ name: 'Alice', bio: 'Bio here' }]} />);
+      render(<ResourcesPanel resources={[]} speakers={[{ name: 'Alice', bio: 'Bio here' }]} />);
       expect(screen.queryByText('Speakers', { selector: 'h4' })).not.toBeInTheDocument();
       expect(screen.queryByText('Alice')).not.toBeInTheDocument();
     });
 
     it('shows ExpandMore icon when collapsed and ExpandLess when expanded', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} />);
-      // MUI renders icons with data-testid like "ExpandMoreIcon"
+      render(<ResourcesPanel resources={[]} />);
       expect(screen.getAllByTestId('ExpandMoreIcon')).toHaveLength(2);
 
       await user.click(screen.getByText('Speakers'));
@@ -118,7 +89,7 @@ describe('ResourcesPanel', () => {
   describe('Speakers section', () => {
     it('shows speakers when the Speakers category is expanded', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} speakers={[{ name: 'Dr. Ada Lovelace', bio: 'Pioneer of computing.' }]} />);
+      render(<ResourcesPanel resources={[]} speakers={[{ name: 'Dr. Ada Lovelace', bio: 'Pioneer of computing.' }]} />);
       await user.click(screen.getByText('Speakers'));
       expect(screen.getByText('Dr. Ada Lovelace')).toBeInTheDocument();
       expect(screen.getByText('Pioneer of computing.')).toBeInTheDocument();
@@ -126,7 +97,7 @@ describe('ResourcesPanel', () => {
 
     it('shows moderators when expanded', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} moderators={[{ name: 'Mod One', bio: 'Moderator bio.' }]} />);
+      render(<ResourcesPanel resources={[]} moderators={[{ name: 'Mod One', bio: 'Moderator bio.' }]} />);
       await user.click(screen.getByText('Speakers'));
       expect(screen.getByText('Moderators')).toBeInTheDocument();
       expect(screen.getByText('Mod One')).toBeInTheDocument();
@@ -136,7 +107,7 @@ describe('ResourcesPanel', () => {
       const user = userEvent.setup();
       render(
         <ResourcesPanel
-          messages={[]}
+          resources={[]}
           speakers={[{ name: 'Speaker A', bio: 'Speaker bio.' }]}
           moderators={[{ name: 'Mod B', bio: 'Mod bio.' }]}
         />,
@@ -150,7 +121,7 @@ describe('ResourcesPanel', () => {
 
     it('does not render Moderators sub-heading when moderators array is empty', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} speakers={[{ name: 'Speaker A', bio: 'Bio.' }]} moderators={[]} />);
+      render(<ResourcesPanel resources={[]} speakers={[{ name: 'Speaker A', bio: 'Bio.' }]} moderators={[]} />);
       await user.click(screen.getByText('Speakers'));
       expect(screen.queryByText('Moderators')).not.toBeInTheDocument();
     });
@@ -158,7 +129,7 @@ describe('ResourcesPanel', () => {
     it('truncates long speaker bios and allows expansion', async () => {
       const user = userEvent.setup();
       const longBio = 'X'.repeat(400);
-      render(<ResourcesPanel messages={[]} speakers={[{ name: 'Speaker A', bio: longBio }]} />);
+      render(<ResourcesPanel resources={[]} speakers={[{ name: 'Speaker A', bio: longBio }]} />);
       await user.click(screen.getByText('Speakers'));
       expect(screen.getByText('more')).toBeInTheDocument();
       await user.click(screen.getByText('more'));
@@ -167,114 +138,85 @@ describe('ResourcesPanel', () => {
 
     it('collapses the speakers section when header is clicked again', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} speakers={[{ name: 'Speaker A', bio: 'Bio.' }]} />);
-      // Click the category header button to expand
+      render(<ResourcesPanel resources={[]} speakers={[{ name: 'Speaker A', bio: 'Bio.' }]} />);
       await user.click(screen.getByRole('button', { name: /speakers/i }));
       expect(screen.getByText('Speaker A')).toBeInTheDocument();
-      // Click again to collapse — re-query to get a fresh reference
       await user.click(screen.getByRole('button', { name: /speakers/i }));
       expect(screen.queryByText('Speaker A')).not.toBeInTheDocument();
     });
   });
 
   describe('Readings & References section', () => {
-    it('shows empty state when there are no readings', async () => {
+    it('shows empty state when there are no resources', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} />);
+      render(<ResourcesPanel resources={[]} />);
       await user.click(screen.getByText('Readings & References'));
       expect(screen.getByText('No reading recommendations available yet.')).toBeInTheDocument();
     });
 
-    it('displays readings parsed from messages', async () => {
+    it('displays resources', async () => {
       const user = userEvent.setup();
-      mockParseMessageBody.mockReturnValueOnce({
-        text: '',
-        type: 'reading',
-        content: [
-          {
-            title: 'The Internet and Democracy',
-            authors: ['Jane Doe', 'John Smith'],
-            year: 2021,
-            abstract: 'An abstract about internet and democracy.',
-            relevanceReason: "Directly relevant to today's discussion.",
-          },
-        ],
-      });
+      const resource = makeResource({ source: 'ai' });
 
-      render(<ResourcesPanel messages={[readingMessage]} />);
+      render(<ResourcesPanel resources={[resource]} />);
       await user.click(screen.getByText('Readings & References'));
 
       expect(screen.getByText('The Internet and Democracy')).toBeInTheDocument();
       expect(screen.getByText('Jane Doe, John Smith (2021)')).toBeInTheDocument();
-      // relevanceReason takes priority over abstract when both are present
       expect(screen.getByText("Directly relevant to today's discussion.")).toBeInTheDocument();
-      expect(screen.queryByText('An abstract about internet and democracy.')).not.toBeInTheDocument();
       expect(screen.getByText('AI Pick')).toBeInTheDocument();
     });
 
-    it('renders reading without optional abstract and relevanceReason', async () => {
+    it('shows Speaker Pick label for speaker-sourced resources', async () => {
       const user = userEvent.setup();
-      mockParseMessageBody.mockReturnValueOnce({
-        text: '',
-        type: 'reading',
-        content: [
-          {
-            title: 'Digital Governance',
-            authors: ['Alice Wang'],
-            year: 2019,
-          },
-        ],
-      });
+      const resource = makeResource({ source: 'speaker' });
 
-      render(<ResourcesPanel messages={[readingMessageNoOptionals]} />);
+      render(<ResourcesPanel resources={[resource]} />);
       await user.click(screen.getByText('Readings & References'));
 
-      expect(screen.getByText('Digital Governance')).toBeInTheDocument();
-      expect(screen.getByText('Alice Wang (2019)')).toBeInTheDocument();
-      expect(screen.queryByText("Why it's relevant:")).not.toBeInTheDocument();
+      expect(screen.getByText('Speaker Pick')).toBeInTheDocument();
     });
 
-    it('aggregates readings from multiple messages', async () => {
-      const msg1 = makeMessage({ type: 'reading', content: [{ title: 'Book One', authors: ['Author A'], year: 2020 }] });
-      const msg2 = makeMessage({ type: 'reading', content: [{ title: 'Book Two', authors: ['Author B'], year: 2022 }] });
-
-      mockParseMessageBody
-        .mockReturnValueOnce({
-          text: '',
-          type: 'reading',
-          content: [{ title: 'Book One', authors: ['Author A'], year: 2020 }],
-        })
-        .mockReturnValueOnce({
-          text: '',
-          type: 'reading',
-          content: [{ title: 'Book Two', authors: ['Author B'], year: 2022 }],
-        });
-
+    it('renders resource without optional fields', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[msg1, msg2]} />);
+      const resource = makeResource({ relevanceReason: undefined, description: undefined, summary: undefined, authors: [] });
+
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Readings & References'));
+
+      expect(screen.getByText('The Internet and Democracy')).toBeInTheDocument();
+    });
+
+    it('displays multiple resources', async () => {
+      const user = userEvent.setup();
+      const res1 = makeResource({ id: 'res-1', title: 'Book One', authors: ['Author A'] });
+      const res2 = makeResource({ id: 'res-2', title: 'Book Two', authors: ['Author B'] });
+
+      render(<ResourcesPanel resources={[res1, res2]} />);
       await user.click(screen.getByText('Readings & References'));
 
       expect(screen.getByText('Book One')).toBeInTheDocument();
       expect(screen.getByText('Book Two')).toBeInTheDocument();
     });
 
-    it('ignores non-reading messages', async () => {
-      const nonReadingMsg = makeMessage({ type: 'assistant', text: 'Hello' });
-      mockParseMessageBody.mockReturnValueOnce({
-        text: 'Hello',
-        type: 'assistant',
+    it('prefers relevanceReason over description and summary', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({
+        relevanceReason: 'Relevance note',
+        description: 'Description text',
+        summary: 'Summary text',
       });
 
-      const user = userEvent.setup();
-      render(<ResourcesPanel messages={[nonReadingMsg]} />);
+      render(<ResourcesPanel resources={[resource]} />);
       await user.click(screen.getByText('Readings & References'));
 
-      expect(screen.getByText('No reading recommendations available yet.')).toBeInTheDocument();
+      expect(screen.getByText('Relevance note')).toBeInTheDocument();
+      expect(screen.queryByText('Description text')).not.toBeInTheDocument();
     });
 
     it('collapses the readings section when clicked again', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} />);
+      render(<ResourcesPanel resources={[]} />);
       await user.click(screen.getByText('Readings & References'));
       expect(screen.getByText('No reading recommendations available yet.')).toBeInTheDocument();
       await user.click(screen.getByText('Readings & References'));
@@ -284,18 +226,17 @@ describe('ResourcesPanel', () => {
 
   describe('unseenReadingsCount badge', () => {
     it('does not show badge when unseenReadingsCount is 0', () => {
-      render(<ResourcesPanel messages={[]} unseenReadingsCount={0} />);
+      render(<ResourcesPanel resources={[]} unseenReadingsCount={0} />);
       expect(screen.queryByText('0')).not.toBeInTheDocument();
     });
 
     it('shows badge with count when unseenReadingsCount > 0', () => {
-      render(<ResourcesPanel messages={[]} unseenReadingsCount={3} />);
+      render(<ResourcesPanel resources={[]} unseenReadingsCount={3} />);
       expect(screen.getByText('3')).toBeInTheDocument();
     });
 
     it('does not show badge for the Speakers category regardless', () => {
-      render(<ResourcesPanel messages={[]} unseenReadingsCount={5} speakers={[{ name: 'S', bio: 'B' }]} />);
-      // Badge "5" should appear once (Readings), not duplicated for Speakers
+      render(<ResourcesPanel resources={[]} unseenReadingsCount={5} speakers={[{ name: 'S', bio: 'B' }]} />);
       expect(screen.getAllByText('5')).toHaveLength(1);
     });
   });
@@ -304,7 +245,7 @@ describe('ResourcesPanel', () => {
     it('does not call onMarkReadingsAsSeen when readings section is expanded', async () => {
       const user = userEvent.setup();
       const onMarkReadingsAsSeen = jest.fn();
-      render(<ResourcesPanel messages={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} />);
+      render(<ResourcesPanel resources={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} />);
       await user.click(screen.getByText('Readings & References'));
       expect(onMarkReadingsAsSeen).not.toHaveBeenCalled();
     });
@@ -312,7 +253,7 @@ describe('ResourcesPanel', () => {
     it('calls onMarkReadingsAsSeen when collapsing readings section', async () => {
       const user = userEvent.setup();
       const onMarkReadingsAsSeen = jest.fn();
-      render(<ResourcesPanel messages={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} />);
+      render(<ResourcesPanel resources={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} />);
       await user.click(screen.getByText('Readings & References')); // expand
       await user.click(screen.getByText('Readings & References')); // collapse
       expect(onMarkReadingsAsSeen).toHaveBeenCalledTimes(1);
@@ -322,7 +263,7 @@ describe('ResourcesPanel', () => {
       const user = userEvent.setup();
       const onMarkReadingsAsSeen = jest.fn();
       render(
-        <ResourcesPanel messages={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} speakers={[{ name: 'S', bio: 'B' }]} />,
+        <ResourcesPanel resources={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} speakers={[{ name: 'S', bio: 'B' }]} />,
       );
       await user.click(screen.getByText('Speakers'));
       expect(onMarkReadingsAsSeen).not.toHaveBeenCalled();
@@ -330,73 +271,48 @@ describe('ResourcesPanel', () => {
 
     it('does not throw when onMarkReadingsAsSeen is not provided', async () => {
       const user = userEvent.setup();
-      render(<ResourcesPanel messages={[]} />);
+      render(<ResourcesPanel resources={[]} />);
       await expect(user.click(screen.getByText('Readings & References'))).resolves.not.toThrow();
     });
   });
 
-  describe('newReadingMessageIds highlighting', () => {
-    it("shows 'New' badge on readings whose messageId is in newReadingMessageIds", async () => {
+  describe('newResourceIds highlighting', () => {
+    it("shows 'New' badge on resources whose id is in newResourceIds", async () => {
       const user = userEvent.setup();
-      mockParseMessageBody.mockReturnValueOnce({
-        text: '',
-        type: 'reading',
-        content: [{ title: 'New Paper', authors: ['Author X'], year: 2024 }],
-      });
+      const resource = makeResource({ id: 'res-1' });
 
-      render(<ResourcesPanel messages={[readingMessage]} newReadingMessageIds={new Set(['msg-1'])} />);
+      render(<ResourcesPanel resources={[resource]} newResourceIds={new Set(['res-1'])} />);
       await user.click(screen.getByText('Readings & References'));
       expect(screen.getByText('New')).toBeInTheDocument();
     });
 
-    it("does not show 'New' badge when messageId is not in newReadingMessageIds", async () => {
+    it("does not show 'New' badge when resource id is not in newResourceIds", async () => {
       const user = userEvent.setup();
-      mockParseMessageBody.mockReturnValueOnce({
-        text: '',
-        type: 'reading',
-        content: [{ title: 'Old Paper', authors: ['Author Y'], year: 2020 }],
-      });
+      const resource = makeResource({ id: 'res-1' });
 
-      render(<ResourcesPanel messages={[readingMessage]} newReadingMessageIds={new Set(['other-msg-id'])} />);
+      render(<ResourcesPanel resources={[resource]} newResourceIds={new Set(['other-res-id'])} />);
       await user.click(screen.getByText('Readings & References'));
       expect(screen.queryByText('New')).not.toBeInTheDocument();
     });
 
-    it("does not show 'New' badge when newReadingMessageIds is not provided", async () => {
+    it("does not show 'New' badge when newResourceIds is not provided", async () => {
       const user = userEvent.setup();
-      mockParseMessageBody.mockReturnValueOnce({
-        text: '',
-        type: 'reading',
-        content: [{ title: 'Some Paper', authors: ['Author Z'], year: 2022 }],
-      });
+      const resource = makeResource({ id: 'res-1' });
 
-      render(<ResourcesPanel messages={[readingMessage]} />);
+      render(<ResourcesPanel resources={[resource]} />);
       await user.click(screen.getByText('Readings & References'));
       expect(screen.queryByText('New')).not.toBeInTheDocument();
     });
 
-    it('applies amber styling only to new readings, not all readings', async () => {
+    it('applies amber styling only to new resources, not all resources', async () => {
       const user = userEvent.setup();
-      const msg1 = { id: 'msg-new', body: {} } as unknown as PseudonymousMessage;
-      const msg2 = { id: 'msg-old', body: {} } as unknown as PseudonymousMessage;
+      const res1 = makeResource({ id: 'res-new', title: 'New Reading' });
+      const res2 = makeResource({ id: 'res-old', title: 'Old Reading' });
 
-      mockParseMessageBody
-        .mockReturnValueOnce({
-          text: '',
-          type: 'reading',
-          content: [{ title: 'New Reading', authors: ['A'], year: 2024 }],
-        })
-        .mockReturnValueOnce({
-          text: '',
-          type: 'reading',
-          content: [{ title: 'Old Reading', authors: ['B'], year: 2020 }],
-        });
-
-      render(<ResourcesPanel messages={[msg1, msg2]} newReadingMessageIds={new Set(['msg-new'])} />);
+      render(<ResourcesPanel resources={[res1, res2]} newResourceIds={new Set(['res-new'])} />);
       await user.click(screen.getByText('Readings & References'));
 
       expect(screen.getByText('New')).toBeInTheDocument();
-      // Only one "New" badge even though there are two readings
       expect(screen.getAllByText('New')).toHaveLength(1);
     });
   });
@@ -406,7 +322,7 @@ describe('ResourcesPanel', () => {
       const user = userEvent.setup();
       render(
         <ResourcesPanel
-          messages={[]}
+          resources={[]}
           speakers={[
             { name: 'Speaker One', bio: 'Bio one.' },
             { name: 'Speaker Two', bio: 'Bio two.' },
@@ -424,7 +340,7 @@ describe('ResourcesPanel', () => {
       const user = userEvent.setup();
       render(
         <ResourcesPanel
-          messages={[]}
+          resources={[]}
           moderators={[
             { name: 'Mod Alpha', bio: 'Alpha bio.' },
             { name: 'Mod Beta', bio: 'Beta bio.' },

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -2680,30 +2680,27 @@ describe('EventAssistantRoom', () => {
     });
   });
 
-  describe('Resources channel', () => {
-    const resourcesSetup = async () => {
-      mockRouter.query = {
-        conversationId: 'test-conversation-id',
-        channel: 'resources,resources-pass',
-      };
+  describe('Resources', () => {
+    const mockResources = [
+      { id: 'res-1', source: 'ai', category: 'suggested', title: 'Book A', participantVisible: true },
+      { id: 'res-2', source: 'ai', category: 'suggested', title: 'Book B', participantVisible: true },
+    ];
+
+    const resourcesSetup = async (resources = mockResources) => {
+      mockRouter.query = { conversationId: 'test-conversation-id' };
 
       (RetrieveData as jest.Mock).mockImplementation((path: string) => {
         if (path.startsWith('conversations/')) {
-          return Promise.resolve({
-            agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
-          });
-        } else if (path.includes('?channel=resources,')) {
-          return Promise.resolve([]);
-        } else if (path.startsWith('messages/')) {
-          return Promise.resolve([]);
+          return Promise.resolve({ agents: [{ id: 'agent-123', agentType: 'eventAssistant' }] });
         }
-        return Promise.resolve(null);
+        return Promise.resolve([]);
       });
 
       (createConversationFromData as jest.Mock).mockResolvedValue({
         agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
         type: { name: 'eventAssistant' },
         name: 'Tech Forum',
+        resources,
       });
 
       await act(async () => {
@@ -2713,201 +2710,33 @@ describe('EventAssistantRoom', () => {
       await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
     };
 
-    /** Grab the most recently registered message:new handler from the socket mock. */
-    const getMessageHandler = (): Function => {
+    /** Grab the most recently registered resources:updated handler from the socket mock. */
+    const getResourcesUpdatedHandler = (): Function => {
       const handler = mockSocket.on.mock.calls
-        .filter(([event]: [string]) => event === 'message:new')
+        .filter(([event]: [string]) => event === 'resources:updated')
         .map(([, h]: [string, Function]) => h)
         .at(-1)!;
       expect(handler).toBeDefined();
       return handler;
     };
 
-    it('includes resources channel in conversation:join when resourcesPasscode is set', async () => {
+    it('registers a resources:updated socket listener', async () => {
       await resourcesSetup();
-
       await waitFor(() => {
-        expect(mockSocket.emit).toHaveBeenCalledWith(
-          'conversation:join',
-          expect.objectContaining({
-            channels: expect.arrayContaining([{ name: 'resources', passcode: 'resources-pass', direct: false }]),
-          }),
-        );
+        expect(mockSocket.on).toHaveBeenCalledWith('resources:updated', expect.any(Function));
       });
     });
 
-    it('fetches initial resources messages when resourcesPasscode is available', async () => {
-      await resourcesSetup();
-
-      await waitFor(() => {
-        expect(RetrieveData).toHaveBeenCalledWith(
-          'messages/test-conversation-id?channel=resources,resources-pass',
-          'mock-access-token',
-        );
-      });
-    });
-
-    it('populates resourcesMessages from initial fetch', async () => {
-      const mockResourcesMessages = [
-        {
-          id: 'res-1',
-          body: {
-            type: 'reading',
-            content: [{ title: 'Book A', authors: ['A'], year: 2020 }],
-          },
-          channels: ['resources'],
-        },
-      ];
-
-      mockRouter.query = {
-        conversationId: 'test-conversation-id',
-        channel: 'resources,resources-pass',
-      };
-
-      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
-        if (path.startsWith('conversations/')) {
-          return Promise.resolve({
-            agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
-          });
-        } else if (path.includes('?channel=resources,')) {
-          return Promise.resolve(mockResourcesMessages);
-        }
-        return Promise.resolve([]);
-      });
-
-      (createConversationFromData as jest.Mock).mockResolvedValue({
-        agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
-        type: { name: 'eventAssistant' },
-        name: 'Tech Forum',
-      });
-
-      await act(async () => {
-        render(<EventAssistantRoom authType={'guest'} />);
-      });
-
-      await waitFor(() => {
-        expect(RetrieveData).toHaveBeenCalledWith(
-          'messages/test-conversation-id?channel=resources,resources-pass',
-          'mock-access-token',
-        );
-      });
-    });
-
-    it('routes incoming socket message with resources channel to resourcesMessages', async () => {
-      await resourcesSetup();
-
-      const user = userEvent.setup();
-      // Navigate to resources tab so the panel renders
-      const resourcesTab = screen.getAllByLabelText('Resources')[0];
-      await user.click(resourcesTab);
-
-      await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith('message:new', expect.any(Function));
-      });
-
-      const messageHandler = getMessageHandler();
-
-      act(() => {
-        messageHandler({
-          id: 'res-msg-1',
-          body: { type: 'reading', content: [] },
-          channels: ['resources'],
-          pseudonym: 'System',
-        });
-      });
-
-      // The ResourcesPanel should still be visible after the message arrives
-      await waitFor(() => {
-        expect(screen.getByText('Readings & References')).toBeInTheDocument();
-      });
-    });
-
-    it('increments unseenResourcesCount when a resources message arrives and the resources tab is NOT active', async () => {
-      await resourcesSetup();
-
-      await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith('message:new', expect.any(Function));
-      });
-
-      const messageHandler = getMessageHandler();
-
-      // Default tab is chat — unseen count should increment, showing the dot badge
-      act(() => {
-        messageHandler({
-          id: 'res-1',
-          channels: ['resources'],
-          body: {
-            type: 'reading',
-            content: [{ title: 'Book A', authors: ['Author'], year: 2020 }],
-          },
-        });
-      });
-
-      // NavigationBar uses MUI Badge dot variant — a visible badge has no MuiBadge-invisible class
-      await waitFor(() => {
-        const badges = document.querySelectorAll('.MuiBadge-badge');
-        const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
-        expect(visibleBadges.length).toBeGreaterThan(0);
-      });
-    });
-
-    it('does NOT increment unseenResourcesCount when a resources message arrives and resources tab IS active', async () => {
+    it('initializes resources from conversation data', async () => {
       await resourcesSetup();
 
       const user = userEvent.setup();
       await user.click(screen.getAllByLabelText('Resources')[0]);
+      await user.click(screen.getByText('Readings & References'));
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith('message:new', expect.any(Function));
-      });
-
-      const messageHandler = getMessageHandler();
-
-      act(() => {
-        messageHandler({
-          id: 'res-1',
-          channels: ['resources'],
-          body: { type: 'reading', content: [] },
-        });
-      });
-
-      // No dot badge should be visible since we're already on the resources tab
-      await waitFor(() => {
-        const badges = document.querySelectorAll('.MuiBadge-badge');
-        const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
-        expect(visibleBadges.length).toBe(0);
-      });
-    });
-
-    it('resets unseenResourcesCount to 0 when switching to the resources tab', async () => {
-      await resourcesSetup();
-
-      await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith('message:new', expect.any(Function));
-      });
-
-      const messageHandler = getMessageHandler();
-
-      // Deliver a message while on another tab to bump the count
-      act(() => {
-        messageHandler({ id: 'res-1', channels: ['resources'], body: {} });
-      });
-
-      // Badge dot should be visible
-      await waitFor(() => {
-        const badges = document.querySelectorAll('.MuiBadge-badge');
-        const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
-        expect(visibleBadges.length).toBeGreaterThan(0);
-      });
-
-      // Switch to resources tab — count clears, badge becomes invisible
-      const user = userEvent.setup();
-      await user.click(screen.getAllByLabelText('Resources')[0]);
-
-      await waitFor(() => {
-        const badges = document.querySelectorAll('.MuiBadge-badge');
-        const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
-        expect(visibleBadges.length).toBe(0);
+        expect(screen.getByText('Book A')).toBeInTheDocument();
+        expect(screen.getByText('Book B')).toBeInTheDocument();
       });
     });
 
@@ -2922,66 +2751,79 @@ describe('EventAssistantRoom', () => {
       });
     });
 
-    it('does NOT route resources messages to assistantMessages or chatMessages', async () => {
-      await resourcesSetup();
+    it('Resources tab is always present in the nav', async () => {
+      await resourcesSetup([]);
+      expect(screen.getAllByLabelText('Resources').length).toBeGreaterThan(0);
+    });
+
+    it('increments unseenResourcesCount when resources:updated adds new resources and the resources tab is NOT active', async () => {
+      await resourcesSetup([]);
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith('message:new', expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith('resources:updated', expect.any(Function));
       });
 
-      const messageHandler = getMessageHandler();
+      const handler = getResourcesUpdatedHandler();
 
       act(() => {
-        messageHandler({
-          id: 'res-1',
-          channels: ['resources'],
-          body: { text: 'Resources only' },
+        handler({
+          resources: [{ id: 'res-new-1', source: 'ai', category: 'suggested', title: 'New Book', participantVisible: true }],
         });
       });
 
-      // Switch to assistant tab and confirm the message isn't rendered there
-      const user = userEvent.setup();
-      await user.click(screen.getAllByLabelText('Berkie')[0]);
-
       await waitFor(() => {
-        expect(screen.queryByText('Resources only')).not.toBeInTheDocument();
+        const badges = document.querySelectorAll('.MuiBadge-badge');
+        const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
+        expect(visibleBadges.length).toBeGreaterThan(0);
       });
     });
 
-    it('increments unseenResourcesCount by the number of items in a multi-item reading message', async () => {
-      await resourcesSetup();
+    it('does NOT increment unseenResourcesCount when resources:updated fires and the resources tab IS active', async () => {
+      await resourcesSetup([]);
+
+      const user = userEvent.setup();
+      await user.click(screen.getAllByLabelText('Resources')[0]);
 
       await waitFor(() => {
-        expect(mockSocket.on).toHaveBeenCalledWith('message:new', expect.any(Function));
+        expect(mockSocket.on).toHaveBeenCalledWith('resources:updated', expect.any(Function));
       });
 
-      const messageHandler = getMessageHandler();
+      const handler = getResourcesUpdatedHandler();
 
-      // Message with 3 reading items — count should go up by 3, not 1
       act(() => {
-        messageHandler({
-          id: 'res-multi',
-          channels: ['resources'],
-          body: {
-            type: 'reading',
-            content: [
-              { title: 'Book A', authors: ['A'], year: 2020 },
-              { title: 'Book B', authors: ['B'], year: 2021 },
-              { title: 'Book C', authors: ['C'], year: 2022 },
-            ],
-          },
+        handler({
+          resources: [{ id: 'res-new-1', source: 'ai', category: 'suggested', title: 'New Book', participantVisible: true }],
         });
       });
 
-      // Switch to resources tab to see the reset value, confirming the count was > 1
-      // by checking badge was visible before switching
+      await waitFor(() => {
+        const badges = document.querySelectorAll('.MuiBadge-badge');
+        const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
+        expect(visibleBadges.length).toBe(0);
+      });
+    });
+
+    it('resets unseenResourcesCount to 0 when switching to the resources tab', async () => {
+      await resourcesSetup([]);
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith('resources:updated', expect.any(Function));
+      });
+
+      const handler = getResourcesUpdatedHandler();
+
+      act(() => {
+        handler({
+          resources: [{ id: 'res-new-1', source: 'ai', category: 'suggested', title: 'New Book', participantVisible: true }],
+        });
+      });
+
       await waitFor(() => {
         const badges = document.querySelectorAll('.MuiBadge-badge');
         const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
         expect(visibleBadges.length).toBeGreaterThan(0);
       });
 
-      // Switch to resources tab — count resets to 0 (confirming it was > 0)
       const user = userEvent.setup();
       await user.click(screen.getAllByLabelText('Resources')[0]);
 
@@ -2992,59 +2834,77 @@ describe('EventAssistantRoom', () => {
       });
     });
 
-    it('Resources tab is always present in the nav even without a resourcesPasscode', async () => {
-      mockRouter.query = { conversationId: 'test-conversation-id' };
+    it('re-fetches resources from conversation API after gap-reconnect', async () => {
+      const updatedResources = [
+        ...mockResources,
+        { id: 'res-3', source: 'ai', category: 'suggested', title: 'Book C', participantVisible: true },
+      ];
 
+      await resourcesSetup(mockResources);
+
+      // Simulate a gap-reconnect by re-rendering with lastReconnectTime set
       (RetrieveData as jest.Mock).mockImplementation((path: string) => {
         if (path.startsWith('conversations/')) {
           return Promise.resolve({
             agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
+            resources: updatedResources,
           });
         }
         return Promise.resolve([]);
       });
 
-      (createConversationFromData as jest.Mock).mockResolvedValue({
-        agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
-        type: { name: 'eventAssistant' },
+      act(() => {
+        mockUseSessionJoin.mockReturnValue({
+          socket: mockSocket,
+          pseudonym: 'test-pseudonym',
+          userId: 'user-123',
+          isConnected: true,
+          errorMessage: null,
+          lastReconnectTime: new Date(),
+        });
       });
 
+      // Re-render to trigger the lastReconnectTime effect
       await act(async () => {
         render(<EventAssistantRoom authType={'guest'} />);
       });
 
-      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
+      await waitFor(() => {
+        expect(RetrieveData).toHaveBeenCalledWith(
+          `conversations/test-conversation-id`,
+          'mock-access-token',
+        );
+      });
 
-      expect(screen.getAllByLabelText('Resources').length).toBeGreaterThan(0);
+      const user = userEvent.setup();
+      await user.click(screen.getAllByLabelText('Resources')[0]);
+      await user.click(screen.getAllByText('Readings & References')[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('Book C')).toBeInTheDocument();
+      });
     });
 
-    it('does not fetch resources messages when no resourcesPasscode is provided', async () => {
-      mockRouter.query = { conversationId: 'test-conversation-id' };
+    it('does not increment count for resources already present in conversation data', async () => {
+      await resourcesSetup(mockResources);
 
-      (RetrieveData as jest.Mock).mockImplementation((path: string) => {
-        if (path.startsWith('conversations/')) {
-          return Promise.resolve({
-            agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
-          });
-        }
-        return Promise.resolve([]);
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith('resources:updated', expect.any(Function));
       });
 
-      (createConversationFromData as jest.Mock).mockResolvedValue({
-        agents: [{ id: 'agent-123', agentType: 'eventAssistant' }],
-        type: { name: 'eventAssistant' },
+      const handler = getResourcesUpdatedHandler();
+
+      // Fire resources:updated with the same resources (no new IDs)
+      act(() => {
+        handler({ resources: mockResources });
       });
 
-      await act(async () => {
-        render(<EventAssistantRoom authType={'guest'} />);
+      // No badge should appear since no new resources were added
+      await waitFor(() => {
+        const badges = document.querySelectorAll('.MuiBadge-badge');
+        const visibleBadges = Array.from(badges).filter((b) => !b.classList.contains('MuiBadge-invisible'));
+        expect(visibleBadges.length).toBe(0);
       });
-
-      await waitFor(() => expect(createConversationFromData).toHaveBeenCalled());
-
-      const resourcesFetch = (RetrieveData as jest.Mock).mock.calls.find(([path]: [string]) =>
-        path.includes('channel=resources'),
-      );
-      expect(resourcesFetch).toBeUndefined();
     });
   });
 });

--- a/__tests__/utils/Helpers.test.ts
+++ b/__tests__/utils/Helpers.test.ts
@@ -318,65 +318,18 @@ describe('generateEventUrls (via createConversationFromData)', () => {
     getConfigSpy.mockRestore();
   });
 
-  it('generates a participant URL without resources param when no resources channel exists', async () => {
-    const data = { ...baseConversation, channels: [] };
-    const result = await createConversationFromData(data as any);
-    const url = result.eventUrls.participant[0]?.url;
-    expect(url).not.toContain('channel=resources');
-  });
-
-  it('appends resources channel param when a resources channel is present (eventAssistant)', async () => {
-    const data = {
-      ...baseConversation,
-      channels: [{ name: 'resources', passcode: 'res-secret' }],
-    };
-    const result = await createConversationFromData(data as any);
-    const url = result.eventUrls.participant[0]?.url;
-    expect(url).toContain('channel=resources,res-secret');
-  });
-
-  it('appends resources channel param for eventAssistant', async () => {
-    const data = {
-      ...baseConversation,
-      conversationType: 'eventAssistant',
-      agents: [{ id: 'agent-1', agentType: 'eventAssistant' }],
-      channels: [{ name: 'resources', passcode: 'res-plus' }],
-    };
-    const result = await createConversationFromData(data as any);
-    const url = result.eventUrls.participant[0]?.url;
-    expect(url).toContain('channel=resources,res-plus');
-  });
-
-  it('includes resources param after chat param when both channels exist', async () => {
-    const data = {
-      ...baseConversation,
-      channels: [
-        { name: 'chat', passcode: 'chat-secret' },
-        { name: 'resources', passcode: 'res-secret' },
-      ],
-    };
-    const result = await createConversationFromData(data as any);
-    const url = result.eventUrls.participant[0]?.url;
-    expect(url).toContain('channel=chat,chat-secret');
-    expect(url).toContain('channel=resources,res-secret');
-    // resources appears after chat in the URL
-    expect(url.indexOf('channel=chat')).toBeLessThan(url.indexOf('channel=resources'));
-  });
-
-  it('includes transcript, chat, and resources params when all three channels exist', async () => {
+  it('includes transcript and chat params when both channels exist', async () => {
     const data = {
       ...baseConversation,
       channels: [
         { name: 'transcript', passcode: 'tx-pass' },
         { name: 'chat', passcode: 'chat-pass' },
-        { name: 'resources', passcode: 'res-pass' },
       ],
     };
     const result = await createConversationFromData(data as any);
     const url = result.eventUrls.participant[0]?.url;
     expect(url).toContain('channel=transcript,tx-pass');
     expect(url).toContain('channel=chat,chat-pass');
-    expect(url).toContain('channel=resources,res-pass');
   });
 
   it('includes a moderator URL when  moderator channel exists', async () => {

--- a/components/ResourcesPanel.tsx
+++ b/components/ResourcesPanel.tsx
@@ -1,19 +1,20 @@
 'use client';
 
-import React, { useState, useMemo, useEffect } from 'react';
-import { PseudonymousMessage } from '../types.internal';
-import { parseMessageBody } from '../utils/Helpers';
+import React, { useState, useEffect } from 'react';
+import { components } from '../types';
 import { ExpandMore, ExpandLess, MenuBook, Person, Info } from '@mui/icons-material';
 
+type Resource = components['schemas']['Resource'];
+
 interface ResourcesPanelProps {
-  messages: PseudonymousMessage[];
+  resources: Resource[];
   eventDescription?: string;
   speakers?: Array<{ name: string; bio: string }>;
   moderators?: Array<{ name: string; bio: string }>;
   eventName?: string;
   unseenReadingsCount?: number;
   onMarkReadingsAsSeen?: () => void;
-  newReadingMessageIds?: Set<string>;
+  newResourceIds?: Set<string>;
 }
 
 interface CategorySection {
@@ -52,52 +53,32 @@ const TruncatedText: React.FC<TruncatedTextProps> = ({ text, maxLength, classNam
 };
 
 export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
-  messages,
+  resources,
   eventDescription,
   speakers = [],
   moderators = [],
   eventName,
   unseenReadingsCount = 0,
   onMarkReadingsAsSeen,
-  newReadingMessageIds,
+  newResourceIds,
 }) => {
+  const suggestedResources = resources.filter((r) => r.category === 'suggested');
+
   // Track which categories are expanded
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
-  // Snapshot of new reading IDs captured at expand time, so highlights persist
-  // even after the parent clears newReadingMessageIds
-  const [newReadingIdsSnapshot, setNewReadingIdsSnapshot] = useState<Set<string>>(new Set());
+  // Snapshot of new resource IDs captured at expand time, so highlights persist
+  // even after the parent clears newResourceIds
+  const [newResourceIdsSnapshot, setNewResourceIdsSnapshot] = useState<Set<string>>(new Set());
 
-  // When new readings arrive while the section is already expanded, merge them into the snapshot
+  // When new resources arrive while the section is already expanded, merge them into the snapshot
   useEffect(() => {
-    if (!expandedCategories.has('readings') || !newReadingMessageIds) return;
-    setNewReadingIdsSnapshot((prev) => {
-      const hasNew = [...newReadingMessageIds].some((id) => !prev.has(id));
+    if (!expandedCategories.has('readings') || !newResourceIds) return;
+    setNewResourceIdsSnapshot((prev) => {
+      const hasNew = [...newResourceIds].some((id) => !prev.has(id));
       if (!hasNew) return prev;
-      return new Set([...prev, ...newReadingMessageIds]);
+      return new Set([...prev, ...newResourceIds]);
     });
-  }, [newReadingMessageIds, expandedCategories]);
-
-  // Extract reading recommendations from messages
-  const readings = useMemo(() => {
-    const allReadings: Array<{
-      title: string;
-      url?: string;
-      authors: string[];
-      year: number;
-      abstract?: string;
-      relevanceReason?: string;
-      messageId: string;
-    }> = [];
-
-    messages.forEach((msg) => {
-      const parsed = parseMessageBody(msg.body);
-      if (parsed.type === 'reading' && Array.isArray(parsed.content)) {
-        allReadings.push(...parsed.content.map((r) => ({ ...r, messageId: msg.id! })));
-      }
-    });
-
-    return allReadings;
-  }, [messages]);
+  }, [newResourceIds, expandedCategories]);
 
   const categories: CategorySection[] = [
     {
@@ -129,11 +110,11 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
     if (categoryId === 'readings') {
       if (expandedCategories.has(categoryId)) {
         // Mark as seen on collapse so re-expanding doesn't re-show highlights
-        setNewReadingIdsSnapshot(new Set());
+        setNewResourceIdsSnapshot(new Set());
         if (onMarkReadingsAsSeen) onMarkReadingsAsSeen();
       } else {
         // Snapshot current new IDs before clearing, so highlights render correctly
-        setNewReadingIdsSnapshot(new Set(newReadingMessageIds));
+        setNewResourceIdsSnapshot(new Set(newResourceIds));
       }
     }
   };
@@ -263,21 +244,21 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
                 .
               </p>
               <ul className="space-y-4 list-none">
-                {readings.length === 0 ? (
+                {suggestedResources.length === 0 ? (
                   <li className="text-sm text-gray-500 italic">No reading recommendations available yet.</li>
                 ) : (
-                  readings.map((reading) => {
-                    const isNew = newReadingIdsSnapshot.has(reading.messageId);
+                  suggestedResources.map((resource) => {
+                    const isNew = resource.id ? newResourceIdsSnapshot.has(resource.id) : false;
                     return (
                       <li
-                        key={reading.messageId}
+                        key={resource.id}
                         className={`border-l-4 pl-4 py-3 rounded-r ${
                           isNew ? 'border-amber-400 bg-amber-50' : 'border-indigo-400 bg-indigo-50'
                         }`}
                       >
                         <div aria-hidden="true" className="flex items-center gap-2 mb-2">
                           <span className="inline-block text-xs font-semibold text-purple-700 bg-purple-100 px-2 py-0.5 rounded-full">
-                            AI Pick
+                            {resource.source === 'ai' ? 'AI Pick' : 'Speaker Pick'}
                           </span>
                           {isNew && (
                             <span className="inline-block text-xs font-semibold text-amber-800 bg-amber-100 px-2 py-0.5 rounded-full">
@@ -286,22 +267,25 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
                           )}
                         </div>
                         <h3 className={`text-sm font-semibold mb-1 ${isNew ? 'text-amber-900' : 'text-indigo-900'}`}>
-                          {reading.url ? (
-                            <a href={reading.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                              {reading.title}
+                          {resource.url ? (
+                            <a href={resource.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                              {resource.title}
                             </a>
                           ) : (
-                            <span tabIndex={0}>{reading.title}</span>
+                            <span tabIndex={0}>{resource.title}</span>
                           )}
                         </h3>
-                        <p tabIndex={0} className="text-xs text-gray-600 mb-2">
-                          <span className="sr-only">Authors and year: </span>
-                          {reading.authors.join(', ')} ({reading.year})
-                        </p>
-                        {(reading.relevanceReason || reading.abstract) && (
+                        {resource.authors && resource.authors.length > 0 && (
+                          <p tabIndex={0} className="text-xs text-gray-600 mb-2">
+                            <span className="sr-only">Authors and year: </span>
+                            {resource.authors.join(', ')}
+                            {resource.year ? ` (${resource.year})` : ''}
+                          </p>
+                        )}
+                        {(resource.relevanceReason || resource.description || resource.summary) && (
                           <p tabIndex={0} className="text-xs text-gray-700 leading-relaxed mb-2">
                             <span className="sr-only">Relevance: </span>
-                            {reading.relevanceReason || reading.abstract}
+                            {resource.relevanceReason || resource.description || resource.summary}
                           </p>
                         )}
                       </li>

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -9,6 +9,8 @@ import { Api, RetrieveData, SendData, GetChannelPasscode, emitWithTokenRefresh, 
 import { components } from '../types';
 import { ControlledInputConfig, PseudonymousMessage, FeedbackConfig } from '../types.internal';
 import { CheckAuthHeader, createConversationFromData, resolveConversationBotName, parseMessageBody } from '../utils/Helpers';
+
+type Resource = components['schemas']['Resource'];
 import { useAnalytics } from '../hooks/useAnalytics';
 import { useConversationType, useSetBotName, useSetConversationType } from '../context/ConversationTypeContext';
 import { AuthType } from '../types.internal';
@@ -79,8 +81,8 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [resourcesNavBadgeDismissed, setResourcesNavBadgeDismissed] = useState(false);
   const [unreadAssistantReplyCount, setUnreadAssistantReplyCount] = useState<number>(0);
   const [unreadChatReplyCount, setUnreadChatReplyCount] = useState<number>(0);
-  // Track which resource message IDs contain new (unseen) readings for highlighting
-  const [newReadingMessageIds, setNewReadingMessageIds] = useState<Set<string>>(new Set());
+  // Track which resource IDs are new (unseen) for highlighting
+  const [newResourceIds, setNewResourceIds] = useState<Set<string>>(new Set());
 
   // Track previous reply counts for chat messages (persists across tab switches)
   const [chatPreviousReplyCounts, setChatPreviousReplyCounts] = useState<Map<string, number>>(new Map());
@@ -88,7 +90,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [assistantPreviousReplyCounts, setAssistantPreviousReplyCounts] = useState<Map<string, number>>(new Map());
   const [assistantMessages, setAssistantMessages] = useState<PseudonymousMessage[]>([]);
   const [chatMessages, setChatMessages] = useState<PseudonymousMessage[]>([]);
-  const [resourcesMessages, setResourcesMessages] = useState<PseudonymousMessage[]>([]);
+  const [resources, setResources] = useState<Resource[]>([]);
   // Tracks whether the first conversation:join has completed so initial message
   // fetches wait until intros (returned in the join callback) are applied first.
   const [initialJoinComplete, setInitialJoinComplete] = useState(false);
@@ -116,7 +118,6 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   const [controlledMode, setControlledMode] = useState<ControlledInputConfig | null>(null);
   const [transcriptPasscode, setTranscriptPasscode] = useState<string>('');
   const [chatPasscode, setChatPasscode] = useState<string>('');
-  const [resourcesPasscode, setResourcesPasscode] = useState<string>('');
   const [eventName, setEventName] = useState<string>('');
   const [eventDescription, setEventDescription] = useState<string>('');
   const [speakers, setSpeakers] = useState<Array<{ name: string; bio: string }>>([]);
@@ -181,21 +182,6 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         if (activeTabRef.current !== 'chat') {
           setUnseenChatCount((prev) => prev + 1);
         }
-      } else if (data.channels && data.channels.includes('resources')) {
-        setResourcesMessages((prev) => [...prev, data]);
-        // Track message ID for highlight on expand
-        if (data.id) {
-          setNewReadingMessageIds((prev) => new Set([...prev, data.id!]));
-        }
-        // Always increment counter so the in-panel badge shows when already on the resources tab
-        const parsed = parseMessageBody(data.body);
-        const readingCount = parsed.type === 'reading' && Array.isArray(parsed.content) ? parsed.content.length : 1;
-        setUnseenResourcesCount((prev) => prev + readingCount);
-        // Only clear the nav badge dismissal when NOT on the resources tab
-        // (nav badge is separately suppressed by resourcesNavBadgeDismissed while on the tab)
-        if (activeTabRef.current !== 'resources') {
-          setResourcesNavBadgeDismissed(false);
-        }
       } else if (!data.channels || !data.channels.includes('transcript')) {
         setAssistantMessages((prev) => [...prev, data]);
         // Increment counter if NOT viewing assistant tab
@@ -213,10 +199,29 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
       }
     };
 
+    const resourcesUpdatedHandler = ({ resources: updatedResources }: { resources: Resource[] }) => {
+      console.log('resources:updated received', updatedResources);
+      setResources((prev) => {
+        const prevIds = new Set(prev.map((r) => r.id).filter(Boolean));
+        const suggested = updatedResources.filter((r) => r.category === 'suggested');
+        const addedIds = suggested.map((r) => r.id).filter((id): id is string => Boolean(id) && !prevIds.has(id));
+        if (addedIds.length > 0) {
+          setNewResourceIds((existing) => new Set([...existing, ...addedIds]));
+          setUnseenResourcesCount((count) => count + addedIds.length);
+          if (activeTabRef.current !== 'resources') {
+            setResourcesNavBadgeDismissed(false);
+          }
+        }
+        return updatedResources;
+      });
+    };
+
     socket.on('message:new', messageHandler);
+    socket.on('resources:updated', resourcesUpdatedHandler);
 
     return () => {
       socket.off('message:new', messageHandler);
+      socket.off('resources:updated', resourcesUpdatedHandler);
     };
   }, [socket, jargonFilterAgentId]);
 
@@ -278,6 +283,10 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
           setModerators(conversation.moderators as Array<{ name: string; bio: string }>);
         }
 
+        if (Array.isArray(conversation?.resources)) {
+          setResources(conversation.resources);
+        }
+
         // Override botName from the first agent's agentConfig if available,
         // falling back to config.conversationBotName
         const resolvedBotName = resolveConversationBotName(conversation, config.conversationBotName);
@@ -296,12 +305,6 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
 
           if (chatPasscodeParam) {
             setChatPasscode(chatPasscodeParam);
-          }
-
-          const resourcesPasscodeParam = GetChannelPasscode('resources', router.query, setLocalError);
-
-          if (resourcesPasscodeParam) {
-            setResourcesPasscode(resourcesPasscodeParam);
           }
         }
 
@@ -369,16 +372,8 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         direct: false,
       });
     }
-    if (resourcesPasscode) {
-      channels.push({
-        name: 'resources',
-        passcode: resourcesPasscode,
-        direct: false,
-      });
-    }
-
     // Nothing to join if there are no channels (e.g. inactive event with no agent
-    // and no chat/resources passcodes — transcript uses its own channel:join).
+    // and no chat passcode — transcript uses its own channel:join).
     if (channels.length === 0) {
       return;
     }
@@ -441,7 +436,6 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     userId,
     userPreferences,
     chatPasscode,
-    resourcesPasscode,
     router.query.conversationId,
   ]);
 
@@ -593,28 +587,6 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     fetchInitialMessages();
   }, [chatPasscode, router.query.conversationId, initialJoinComplete]);
 
-  // Load initial resources messages when resourcesPasscode becomes available
-  useEffect(() => {
-    if (!resourcesPasscode || !router.query.conversationId) return;
-
-    const fetchInitialMessages = async () => {
-      try {
-        const fetchedMessages = await RetrieveData(
-          `messages/${router.query.conversationId}?channel=resources,${resourcesPasscode}`,
-          Api.get().getAccessToken(),
-        );
-
-        if (Array.isArray(fetchedMessages)) {
-          setResourcesMessages(fetchedMessages);
-        }
-      } catch (error) {
-        console.error('Error fetching initial resources messages:', error);
-      }
-    };
-
-    fetchInitialMessages();
-  }, [resourcesPasscode, router.query.conversationId]);
-
   // Check if user has existing preferences
   useEffect(() => {
     if (!userId) return;
@@ -673,19 +645,14 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         .catch((err) => console.error('Error re-fetching chat messages:', err));
     }
 
-    if (resourcesPasscode) {
-      RetrieveData(
-        `messages/${router.query.conversationId}?channel=resources,${resourcesPasscode}`,
-        Api.get().getAccessToken(),
-      )
-        .then((msgs) => {
-          if (Array.isArray(msgs)) setResourcesMessages(msgs);
-        })
-        .catch((err) => console.error('Error re-fetching resources messages:', err));
-    }
+    RetrieveData(`conversations/${router.query.conversationId}`, Api.get().getAccessToken())
+      .then((data) => {
+        if (Array.isArray(data?.resources)) setResources(data.resources);
+      })
+      .catch((err) => console.error('Error re-fetching resources after reconnect:', err));
 
     fetchAllAssistantMessages();
-  }, [lastReconnectTime, router.query.conversationId, chatPasscode, resourcesPasscode, fetchAllAssistantMessages]);
+  }, [lastReconnectTime, router.query.conversationId, chatPasscode, fetchAllAssistantMessages]);
 
   async function sendMessage(
     message: string,
@@ -856,7 +823,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     }
     // Clear reading state when leaving the resources tab
     if (activeTab === 'resources' && tab !== 'resources') {
-      setNewReadingMessageIds(new Set());
+      setNewResourceIds(new Set());
       setUnseenResourcesCount(0);
     }
     // Track tab switch analytics (transcript treated as a nav destination)
@@ -865,7 +832,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
 
   const handleMarkReadingsAsSeen = () => {
     setUnseenResourcesCount(0);
-    setNewReadingMessageIds(new Set());
+    setNewResourceIds(new Set());
   };
 
   // Create feedback config for assistant messages
@@ -955,14 +922,14 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
                         />
                       ) : activeTab === 'resources' ? (
                         <ResourcesPanel
-                          messages={resourcesMessages}
+                          resources={resources}
                           eventDescription={eventDescription}
                           speakers={speakers}
                           moderators={moderators}
                           eventName={eventName}
                           unseenReadingsCount={unseenResourcesCount}
                           onMarkReadingsAsSeen={handleMarkReadingsAsSeen}
-                          newReadingMessageIds={newReadingMessageIds}
+                          newResourceIds={newResourceIds}
                         />
                       ) : (
                         <AssistantChatPanel

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -303,9 +303,6 @@ function generateEventUrls(conversationData: Conversation, botName: string): Eve
   const chatPasscode = conversationData.channels.find((channel) => channel.name === 'chat')?.passcode;
   const hasChat = Boolean(chatPasscode);
 
-  const resourcesPasscode = conversationData.channels.find((channel) => channel.name === 'resources')?.passcode;
-  const hasResources = Boolean(resourcesPasscode);
-
   const modPasscode = conversationData.channels.find((channel) => channel.name === 'moderator')?.passcode;
 
   const modUrl = modPasscode
@@ -334,7 +331,7 @@ function generateEventUrls(conversationData: Conversation, botName: string): Eve
       label: botName,
       url: `${urlPrefix}/assistant/?conversationId=${conversationData.id}${
         hasTranscript ? `&channel=transcript,${transcriptPasscode}` : ''
-      }${hasChat ? `&channel=chat,${chatPasscode}` : ''}${hasResources ? `&channel=resources,${resourcesPasscode}` : ''}`,
+      }${hasChat ? `&channel=chat,${chatPasscode}` : ''}`,
     };
     participant.push(eventAssistantUrl);
     if (modPasscode) {


### PR DESCRIPTION
## What is in this PR?

BE changed to make Resource a first-class object rather than a Message, adjust accordingly to populate the Resources tab. No new user-facing changes.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

See above

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- Test in conjunction with BE PR https://github.com/berkmancenter/llm_engine/pull/123
- [x] Create an EA convo that runs for at least 15 minutes and be sure Reading Recommendations feature is enabled
- [x] Play an event and keep the front end on a tab other than Resources
- [x] Ensure after about 15 mins, you see a notification on the Resources tab
- [x] There should be the number 2 on the Readings accordion on the Resources tab
- [x] Expand and ensure the readings look the same
- [x] Collapse and ensure the 2 goes away
- [x] Reload the page and ensure readings show up again



## Additional information

Deployment failed because new Resource type introduced on BE.
