### PR TITLE
feat: add required reading section to resources tab

### DIFF
--- a/__tests__/components/ResourcesPanel.test.tsx
+++ b/__tests__/components/ResourcesPanel.test.tsx
@@ -67,7 +67,7 @@ describe('ResourcesPanel', () => {
     it('renders Speakers and Readings & References category headers', () => {
       render(<ResourcesPanel resources={[]} />);
       expect(screen.getByText('Speakers')).toBeInTheDocument();
-      expect(screen.getByText('Readings & References')).toBeInTheDocument();
+      expect(screen.getByText('Readings & References (optional)')).toBeInTheDocument();
     });
 
     it('categories are collapsed by default (content not visible)', () => {
@@ -79,7 +79,7 @@ describe('ResourcesPanel', () => {
     it('shows ExpandMore icon when collapsed and ExpandLess when expanded', async () => {
       const user = userEvent.setup();
       render(<ResourcesPanel resources={[]} />);
-      expect(screen.getAllByTestId('ExpandMoreIcon')).toHaveLength(2);
+      expect(screen.getAllByTestId('ExpandMoreIcon')).toHaveLength(3);
 
       await user.click(screen.getByText('Speakers'));
       expect(screen.getAllByTestId('ExpandLessIcon')).toHaveLength(1);
@@ -146,11 +146,118 @@ describe('ResourcesPanel', () => {
     });
   });
 
+  describe('Required Reading section', () => {
+    it('shows empty state when expanded with no required resources', async () => {
+      const user = userEvent.setup();
+      render(<ResourcesPanel resources={[]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText('No required readings assigned yet.')).toBeInTheDocument();
+    });
+
+    it('renders Required Reading header', () => {
+      const resource = makeResource({ category: 'required', source: 'speaker' });
+      render(<ResourcesPanel resources={[resource]} />);
+      expect(screen.getByText('Required Reading')).toBeInTheDocument();
+    });
+
+    it('does not show content when collapsed', () => {
+      const resource = makeResource({ category: 'required', source: 'speaker' });
+      render(<ResourcesPanel resources={[resource]} />);
+      expect(screen.queryByText('The Internet and Democracy')).not.toBeInTheDocument();
+    });
+
+    it('shows resources when expanded', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker' });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText('The Internet and Democracy')).toBeInTheDocument();
+    });
+
+    it('shows singular intro text for one required reading', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker' });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText(/reading was/)).toBeInTheDocument();
+    });
+
+    it('shows plural intro text for multiple required readings', async () => {
+      const user = userEvent.setup();
+      const r1 = makeResource({ id: 'r1', category: 'required', source: 'speaker', title: 'Paper One' });
+      const r2 = makeResource({ id: 'r2', category: 'required', source: 'speaker', title: 'Paper Two' });
+      render(<ResourcesPanel resources={[r1, r2]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText(/2 readings were/)).toBeInTheDocument();
+    });
+
+    it('shows Required badge on each required resource', async () => {
+      const user = userEvent.setup();
+      const r1 = makeResource({ id: 'r1', category: 'required', source: 'speaker', title: 'Paper One' });
+      const r2 = makeResource({ id: 'r2', category: 'required', source: 'speaker', title: 'Paper Two' });
+      render(<ResourcesPanel resources={[r1, r2]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getAllByText('Required')).toHaveLength(2);
+    });
+
+    it('renders authors and year', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker' });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText('Jane Doe, John Smith (2021)')).toBeInTheDocument();
+    });
+
+    it('renders description when present', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker', description: 'A must-read paper.' });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText('A must-read paper.')).toBeInTheDocument();
+    });
+
+    it('renders summary with truncation when present', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker', summary: 'S'.repeat(500) });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText('Summary')).toBeInTheDocument();
+      expect(screen.getByText('more')).toBeInTheDocument();
+    });
+
+    it('renders title as a link when url is present', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker', url: 'https://example.com' });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Required Reading'));
+      const link = screen.getByRole('link', { name: 'The Internet and Democracy' });
+      expect(link).toHaveAttribute('href', 'https://example.com');
+    });
+
+    it('collapses when header is clicked again', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker' });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.getByText('The Internet and Democracy')).toBeInTheDocument();
+      await user.click(screen.getByText('Required Reading'));
+      expect(screen.queryByText('The Internet and Democracy')).not.toBeInTheDocument();
+    });
+
+    it('does not show required resources in Readings & References section', async () => {
+      const user = userEvent.setup();
+      const resource = makeResource({ category: 'required', source: 'speaker' });
+      render(<ResourcesPanel resources={[resource]} />);
+      await user.click(screen.getByText('Readings & References (optional)'));
+      expect(screen.getByText('No reading recommendations available yet.')).toBeInTheDocument();
+    });
+  });
+
   describe('Readings & References section', () => {
     it('shows empty state when there are no resources', async () => {
       const user = userEvent.setup();
       render(<ResourcesPanel resources={[]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
       expect(screen.getByText('No reading recommendations available yet.')).toBeInTheDocument();
     });
 
@@ -159,7 +266,7 @@ describe('ResourcesPanel', () => {
       const resource = makeResource({ source: 'ai' });
 
       render(<ResourcesPanel resources={[resource]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
 
       expect(screen.getByText('The Internet and Democracy')).toBeInTheDocument();
       expect(screen.getByText('Jane Doe, John Smith (2021)')).toBeInTheDocument();
@@ -172,7 +279,7 @@ describe('ResourcesPanel', () => {
       const resource = makeResource({ source: 'speaker' });
 
       render(<ResourcesPanel resources={[resource]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
 
       expect(screen.getByText('Speaker Pick')).toBeInTheDocument();
     });
@@ -182,7 +289,7 @@ describe('ResourcesPanel', () => {
       const resource = makeResource({ relevanceReason: undefined, description: undefined, summary: undefined, authors: [] });
 
       render(<ResourcesPanel resources={[resource]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
 
       expect(screen.getByText('The Internet and Democracy')).toBeInTheDocument();
     });
@@ -193,7 +300,7 @@ describe('ResourcesPanel', () => {
       const res2 = makeResource({ id: 'res-2', title: 'Book Two', authors: ['Author B'] });
 
       render(<ResourcesPanel resources={[res1, res2]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
 
       expect(screen.getByText('Book One')).toBeInTheDocument();
       expect(screen.getByText('Book Two')).toBeInTheDocument();
@@ -208,7 +315,7 @@ describe('ResourcesPanel', () => {
       });
 
       render(<ResourcesPanel resources={[resource]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
 
       expect(screen.getByText('Relevance note')).toBeInTheDocument();
       expect(screen.queryByText('Description text')).not.toBeInTheDocument();
@@ -217,9 +324,9 @@ describe('ResourcesPanel', () => {
     it('collapses the readings section when clicked again', async () => {
       const user = userEvent.setup();
       render(<ResourcesPanel resources={[]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
       expect(screen.getByText('No reading recommendations available yet.')).toBeInTheDocument();
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
       expect(screen.queryByText('No reading recommendations available yet.')).not.toBeInTheDocument();
     });
   });
@@ -246,7 +353,7 @@ describe('ResourcesPanel', () => {
       const user = userEvent.setup();
       const onMarkReadingsAsSeen = jest.fn();
       render(<ResourcesPanel resources={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
       expect(onMarkReadingsAsSeen).not.toHaveBeenCalled();
     });
 
@@ -254,8 +361,8 @@ describe('ResourcesPanel', () => {
       const user = userEvent.setup();
       const onMarkReadingsAsSeen = jest.fn();
       render(<ResourcesPanel resources={[]} onMarkReadingsAsSeen={onMarkReadingsAsSeen} />);
-      await user.click(screen.getByText('Readings & References')); // expand
-      await user.click(screen.getByText('Readings & References')); // collapse
+      await user.click(screen.getByText('Readings & References (optional)')); // expand
+      await user.click(screen.getByText('Readings & References (optional)')); // collapse
       expect(onMarkReadingsAsSeen).toHaveBeenCalledTimes(1);
     });
 
@@ -272,7 +379,7 @@ describe('ResourcesPanel', () => {
     it('does not throw when onMarkReadingsAsSeen is not provided', async () => {
       const user = userEvent.setup();
       render(<ResourcesPanel resources={[]} />);
-      await expect(user.click(screen.getByText('Readings & References'))).resolves.not.toThrow();
+      await expect(user.click(screen.getByText('Readings & References (optional)'))).resolves.not.toThrow();
     });
   });
 
@@ -282,7 +389,7 @@ describe('ResourcesPanel', () => {
       const resource = makeResource({ id: 'res-1' });
 
       render(<ResourcesPanel resources={[resource]} newResourceIds={new Set(['res-1'])} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
       expect(screen.getByText('New')).toBeInTheDocument();
     });
 
@@ -291,7 +398,7 @@ describe('ResourcesPanel', () => {
       const resource = makeResource({ id: 'res-1' });
 
       render(<ResourcesPanel resources={[resource]} newResourceIds={new Set(['other-res-id'])} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
       expect(screen.queryByText('New')).not.toBeInTheDocument();
     });
 
@@ -300,7 +407,7 @@ describe('ResourcesPanel', () => {
       const resource = makeResource({ id: 'res-1' });
 
       render(<ResourcesPanel resources={[resource]} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
       expect(screen.queryByText('New')).not.toBeInTheDocument();
     });
 
@@ -310,7 +417,7 @@ describe('ResourcesPanel', () => {
       const res2 = makeResource({ id: 'res-old', title: 'Old Reading' });
 
       render(<ResourcesPanel resources={[res1, res2]} newResourceIds={new Set(['res-new'])} />);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
 
       expect(screen.getByText('New')).toBeInTheDocument();
       expect(screen.getAllByText('New')).toHaveLength(1);

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -2732,7 +2732,7 @@ describe('EventAssistantRoom', () => {
 
       const user = userEvent.setup();
       await user.click(screen.getAllByLabelText('Resources')[0]);
-      await user.click(screen.getByText('Readings & References'));
+      await user.click(screen.getByText('Readings & References (optional)'));
 
       await waitFor(() => {
         expect(screen.getByText('Book A')).toBeInTheDocument();
@@ -2747,7 +2747,7 @@ describe('EventAssistantRoom', () => {
       await user.click(screen.getAllByLabelText('Resources')[0]);
 
       await waitFor(() => {
-        expect(screen.getByText('Readings & References')).toBeInTheDocument();
+        expect(screen.getByText('Readings & References (optional)')).toBeInTheDocument();
       });
     });
 
@@ -2870,15 +2870,12 @@ describe('EventAssistantRoom', () => {
       });
 
       await waitFor(() => {
-        expect(RetrieveData).toHaveBeenCalledWith(
-          `conversations/test-conversation-id`,
-          'mock-access-token',
-        );
+        expect(RetrieveData).toHaveBeenCalledWith(`conversations/test-conversation-id`, 'mock-access-token');
       });
 
       const user = userEvent.setup();
       await user.click(screen.getAllByLabelText('Resources')[0]);
-      await user.click(screen.getAllByText('Readings & References')[0]);
+      await user.click(screen.getAllByText('Readings & References (optional)')[0]);
 
       await waitFor(() => {
         expect(screen.getByText('Book C')).toBeInTheDocument();

--- a/components/ResourcesPanel.tsx
+++ b/components/ResourcesPanel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { components } from '../types';
-import { ExpandMore, ExpandLess, MenuBook, Person, Info } from '@mui/icons-material';
+import { ExpandMore, ExpandLess, MenuBook, Person, Info, Bookmark } from '@mui/icons-material';
 
 type Resource = components['schemas']['Resource'];
 
@@ -63,6 +63,7 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
   newResourceIds,
 }) => {
   const suggestedResources = resources.filter((r) => r.category === 'suggested');
+  const requiredResources = resources.filter((r) => r.category === 'required');
 
   // Track which categories are expanded
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
@@ -85,12 +86,19 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
       id: 'speakers',
       title: 'Speakers',
       icon: Person,
-      count: 0, // Don't show badge for speakers (static content)
+      count: 0,
+      defaultExpanded: false,
+    },
+    {
+      id: 'required',
+      title: 'Required Reading',
+      icon: Bookmark,
+      count: 0,
       defaultExpanded: false,
     },
     {
       id: 'readings',
-      title: 'Readings & References',
+      title: 'Readings & References (optional)',
       icon: MenuBook,
       count: unseenReadingsCount,
       defaultExpanded: false,
@@ -226,9 +234,73 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
           )}
         </div>
 
+        {/* Required Reading */}
+        <div className="mb-2">
+          <CategoryHeader category={categories[1]} isExpanded={expandedCategories.has('required')} />
+          {expandedCategories.has('required') && (
+            <div className="bg-white px-6 py-4 border-b border-gray-200">
+              {requiredResources.length === 0 ? (
+                <p className="text-sm text-gray-500 italic">No required readings assigned yet.</p>
+              ) : (
+                <>
+                  <p className="text-xs text-gray-600 mb-4">
+                    The following{' '}
+                    {requiredResources.length === 1 ? 'reading was' : `${requiredResources.length} readings were`} assigned
+                    by the event organizer to prepare for this session.
+                  </p>
+                  <ul className="space-y-5 list-none">
+                    {requiredResources.map((resource, idx) => (
+                      <li key={resource.id || idx} className="border border-amber-200 rounded-lg bg-amber-50 p-4">
+                        <div aria-hidden="true" className="flex items-center gap-2 mb-2">
+                          <span className="inline-block text-xs font-semibold text-amber-800 bg-amber-200 px-2 py-0.5 rounded-full">
+                            Required
+                          </span>
+                        </div>
+                        <h3 className="text-sm font-semibold text-amber-900 mb-1">
+                          {resource.url ? (
+                            <a href={resource.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                              {resource.title}
+                            </a>
+                          ) : (
+                            <span tabIndex={0}>{resource.title}</span>
+                          )}
+                        </h3>
+                        {resource.authors && resource.authors.length > 0 && (
+                          <p tabIndex={0} className="text-xs text-gray-600 mb-3">
+                            <span className="sr-only">Authors and year: </span>
+                            {resource.authors.join(', ')}
+                            {resource.year ? ` (${resource.year})` : ''}
+                          </p>
+                        )}
+                        {resource.description && (
+                          <p tabIndex={0} className="text-xs text-gray-600 italic mb-2">
+                            {resource.description}
+                          </p>
+                        )}
+                        {resource.summary && (
+                          <div className="border-t border-amber-200 pt-3 mt-2">
+                            <p className="text-xs font-semibold text-amber-900 mb-1">Summary</p>
+                            <p tabIndex={0} className="text-xs text-gray-700 leading-relaxed">
+                              <TruncatedText
+                                text={resource.summary}
+                                maxLength={400}
+                                className="text-xs text-gray-700 leading-relaxed"
+                              />
+                            </p>
+                          </div>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
         {/* Readings & References */}
         <div className="mb-2">
-          <CategoryHeader category={categories[1]} isExpanded={expandedCategories.has('readings')} />
+          <CategoryHeader category={categories[2]} isExpanded={expandedCategories.has('readings')} />
           {expandedCategories.has('readings') && (
             <div className="bg-white px-6 py-4 border-b border-gray-200">
               <p className="text-xs text-gray-600 mb-3">

--- a/content/whatsNew.ts
+++ b/content/whatsNew.ts
@@ -29,6 +29,11 @@ export const whatsNewEntries: WhatsNewEntry[] = [
     body: 'Find reading recommendations and other resources surfaced during the event in the new Resources tab.',
     releasedAt: '2026-04-27',
   },
+  {
+    title: 'Required Reading',
+    body: 'Event organizers can now assign required readings that are highlighted in the Resources tab.',
+    releasedAt: '2026-05-15',
+  },
 ];
 
 /**


### PR DESCRIPTION
## What is in this PR?

Adds a required reading section to resources tab to display any speaker-provided resources (changes to allow speakers to add these on event creation coming soon)

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

- Static display of required readings on conversation load if present. Should have clickable title (if url provided), author and year info, and an expandable summary (or description or relevanceReason)
- Header for Readings & References changed to include '(optional)'

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [x] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x]  Can verify the Required Reading section shows up for a conversation, but it will be empty. Let me know if you want a mongosh statement to add resources to an existing convo in the DB to test....



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
