### PR TITLE
add resources to event creation form

### DIFF
--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { EventCreationForm } from '../../components/EventCreationForm';
 import { RetrieveData, Request } from '../../utils';
-import { Api } from '../../utils/Helpers';
+import { Api, SendData } from '../../utils/Helpers';
 import '@testing-library/jest-dom';
 
 jest.setTimeout(60000);
@@ -38,6 +38,11 @@ jest.mock('next/router', () => ({
 jest.mock('../../utils', () => ({
   RetrieveData: jest.fn(),
   Request: jest.fn(),
+}));
+
+jest.mock('../../utils/Helpers', () => ({
+  ...jest.requireActual('../../utils/Helpers'),
+  SendData: jest.fn(),
 }));
 
 jest.mock('../../utils/SessionManager', () => ({
@@ -390,7 +395,7 @@ describe('EventCreationForm Component', () => {
     expect(screen.getAllByText('Event Details').length).toBeGreaterThan(0);
     expect(screen.getByText('Conversation Setup')).toBeInTheDocument();
     expect(screen.getByText('Configuration')).toBeInTheDocument();
-    expect(screen.getByText('Moderators & Speakers')).toBeInTheDocument();
+    expect(screen.getByText('Speakers')).toBeInTheDocument();
 
     // Should show Step 1 content
     expect(screen.getByLabelText(/Event Name/i)).toBeInTheDocument();
@@ -749,6 +754,8 @@ describe('EventCreationForm Component', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() => screen.getByText('About the Speakers'));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => screen.getByText('Reading & Resources'));
 
     // Submit form
     const submitButton = screen.getByRole('button', {
@@ -813,6 +820,8 @@ describe('EventCreationForm Component', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() => screen.getByText('About the Speakers'));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => screen.getByText('Reading & Resources'));
 
     const submitButton = screen.getByRole('button', {
       name: /create conversation/i,
@@ -868,6 +877,8 @@ describe('EventCreationForm Component', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() => screen.getByText('About the Speakers'));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => screen.getByText('Reading & Resources'));
 
     const submitButton = screen.getByRole('button', {
       name: /create conversation/i,
@@ -937,6 +948,9 @@ describe('EventCreationForm Component', () => {
     await user.type(moderatorNameInput, 'Jane Smith');
     const moderatorBioInput = screen.getAllByLabelText(/Bio/i)[1];
     await user.type(moderatorBioInput, 'Experienced moderator');
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => screen.getByText('Reading & Resources'));
 
     const submitButton = screen.getByRole('button', {
       name: /create conversation/i,
@@ -1093,6 +1107,8 @@ describe('EventCreationForm Component', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() => screen.getByText('About the Speakers'));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => screen.getByText('Reading & Resources'));
 
     const submitButton = screen.getByRole('button', {
       name: /create conversation/i,
@@ -1148,6 +1164,8 @@ describe('EventCreationForm Component', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() => screen.getByText('About the Speakers'));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await waitFor(() => screen.getByText('Reading & Resources'));
 
     const submitButton = screen.getByRole('button', {
       name: /create conversation/i,
@@ -1312,6 +1330,8 @@ describe('EventCreationForm Component', () => {
       await navigateToStep3WithBackChannel(user);
       await user.click(screen.getByRole('button', { name: /next/i }));
       await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
       await user.click(screen.getByRole('button', { name: /create conversation/i }));
 
       await waitFor(() => {
@@ -1347,6 +1367,8 @@ describe('EventCreationForm Component', () => {
 
       await user.click(screen.getByRole('button', { name: /next/i }));
       await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
       await user.click(screen.getByRole('button', { name: /create conversation/i }));
 
       await waitFor(() => {
@@ -1537,6 +1559,8 @@ describe('EventCreationForm Component', () => {
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
       await user.click(screen.getByRole('button', { name: /create conversation/i }));
 
       await waitFor(() => {
@@ -1763,6 +1787,8 @@ describe('EventCreationForm Component', () => {
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
       await user.click(screen.getByRole('button', { name: /create conversation/i }));
 
       await waitFor(() => {
@@ -1806,6 +1832,8 @@ describe('EventCreationForm Component', () => {
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
       await user.click(screen.getByRole('button', { name: /create conversation/i }));
 
       await waitFor(() => {
@@ -1813,6 +1841,427 @@ describe('EventCreationForm Component', () => {
         // Should NOT have called topics POST to create a new topic
         expect(Request).not.toHaveBeenCalledWith('topics', expect.anything());
       });
+    });
+  });
+
+  describe('Resources (Step 5)', () => {
+    const mockConversationData = {
+      id: 'conv-resources',
+      name: 'Test Event',
+      channels: [],
+      agents: [],
+      adapters: [],
+      conversationType: 'backChannel',
+      resources: [],
+    };
+
+    const navigateToStep5 = async (user: ReturnType<typeof userEvent.setup>) => {
+      await fillEventDetails('Test Event', 'https://huitstage.zoom.us/j/1234567890');
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Nextspace'));
+      await user.click(screen.getByRole('checkbox', { name: /zoom/i }));
+      await user.click(screen.getByRole('radio', { name: /back channel/i }));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByLabelText(/Bot Name/i));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
+    };
+
+    beforeEach(() => {
+      (Request as jest.Mock).mockImplementation(makeRequestMock(mockConversationData));
+      (SendData as jest.Mock).mockResolvedValue({});
+    });
+
+    it('renders step 5 with one resource entry by default', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      expect(screen.getByText('Resource 1')).toBeInTheDocument();
+      expect(screen.getByLabelText(/^Title/i)).toBeInTheDocument();
+    });
+
+    it('renders all resource fields', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      expect(screen.getByLabelText(/^Title/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^URL/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Authors/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Year/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Citation/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
+    });
+
+    it('renders the PDF drop zone', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      expect(screen.getByText(/Drop a PDF here or/i)).toBeInTheDocument();
+      expect(screen.getByText(/Max 20 MB/i)).toBeInTheDocument();
+    });
+
+    it('renders Show to attendees and Mark as required checkboxes', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      expect(screen.getByRole('checkbox', { name: /show to attendees/i })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /mark as required/i })).toBeInTheDocument();
+    });
+
+    it('Show to attendees is checked by default', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      expect(screen.getByRole('checkbox', { name: /show to attendees/i })).toBeChecked();
+    });
+
+    it('Mark as required is unchecked by default', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      expect(screen.getByRole('checkbox', { name: /mark as required/i })).not.toBeChecked();
+    });
+
+    it('Mark as required is disabled when Show to attendees is unchecked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.click(screen.getByRole('checkbox', { name: /show to attendees/i }));
+
+      expect(screen.getByRole('checkbox', { name: /mark as required/i })).toBeDisabled();
+    });
+
+    it('hides Remove button when there is only one resource', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      expect(screen.queryByRole('button', { name: /^remove$/i })).not.toBeInTheDocument();
+    });
+
+    it('adds a second resource entry when Add Resource is clicked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.click(screen.getByRole('button', { name: /\+ Add Resource/i }));
+
+      expect(screen.getByText('Resource 2')).toBeInTheDocument();
+    });
+
+    it('shows Remove button when there are multiple resources', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.click(screen.getByRole('button', { name: /\+ Add Resource/i }));
+
+      expect(screen.getAllByRole('button', { name: /^remove$/i })).toHaveLength(2);
+    });
+
+    it('removes a resource entry when Remove is clicked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.click(screen.getByRole('button', { name: /\+ Add Resource/i }));
+      expect(screen.getByText('Resource 2')).toBeInTheDocument();
+
+      await user.click(screen.getAllByRole('button', { name: /^remove$/i })[0]);
+      expect(screen.queryByText('Resource 2')).not.toBeInTheDocument();
+    });
+
+    it('does not include resources in payload when title is empty', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      // Leave title blank, submit
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        const call = (Request as jest.Mock).mock.calls.find((c) => c[0] === 'conversations/from-type');
+        expect(call![1]).not.toHaveProperty('resources');
+      });
+    });
+
+    it('includes resource in payload when title is filled', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'Attention Is All You Need');
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          'conversations/from-type',
+          expect.objectContaining({
+            resources: expect.arrayContaining([
+              expect.objectContaining({
+                title: 'Attention Is All You Need',
+                source: 'speaker',
+                category: 'suggested',
+                participantVisible: true,
+              }),
+            ]),
+          }),
+        );
+      });
+    });
+
+    it('sends category "required" when Mark as required is checked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'Required Paper');
+      await user.click(screen.getByRole('checkbox', { name: /mark as required/i }));
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          'conversations/from-type',
+          expect.objectContaining({
+            resources: expect.arrayContaining([expect.objectContaining({ category: 'required' })]),
+          }),
+        );
+      });
+    });
+
+    it('sends participantVisible: false when Show to attendees is unchecked', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'Private Paper');
+      await user.click(screen.getByRole('checkbox', { name: /show to attendees/i }));
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          'conversations/from-type',
+          expect.objectContaining({
+            resources: expect.arrayContaining([expect.objectContaining({ participantVisible: false })]),
+          }),
+        );
+      });
+    });
+
+    it('splits authors string into array in the payload', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'Paper');
+      await user.type(screen.getByLabelText(/Authors/i), 'Jane Smith, John Doe');
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          'conversations/from-type',
+          expect.objectContaining({
+            resources: expect.arrayContaining([expect.objectContaining({ authors: ['Jane Smith', 'John Doe'] })]),
+          }),
+        );
+      });
+    });
+
+    it('includes optional fields when provided', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'Full Paper');
+      await user.type(screen.getByLabelText(/^URL/i), 'https://example.com');
+      await user.type(screen.getByLabelText(/Year/i), '2024');
+      await user.type(screen.getByLabelText(/Citation/i), 'Smith et al. (2024).');
+      await user.type(screen.getByLabelText(/Description/i), 'Very relevant.');
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        expect(Request).toHaveBeenCalledWith(
+          'conversations/from-type',
+          expect.objectContaining({
+            resources: expect.arrayContaining([
+              expect.objectContaining({
+                url: 'https://example.com',
+                year: '2024',
+                citation: 'Smith et al. (2024).',
+                description: 'Very relevant.',
+              }),
+            ]),
+          }),
+        );
+      });
+    });
+
+    it('rejects a PDF over 20 MB and shows an error', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      const oversizedFile = new File(['x'.repeat(1)], 'big.pdf', { type: 'application/pdf' });
+      Object.defineProperty(oversizedFile, 'size', { value: 51 * 1024 * 1024 });
+
+      const input = document.getElementById('pdf-upload-0') as HTMLInputElement;
+      await user.upload(input, oversizedFile);
+
+      await waitFor(() => {
+        expect(screen.getByText(/exceeds the 20 MB limit/i)).toBeInTheDocument();
+      });
+    });
+
+    it('accepts a PDF under 20 MB and shows the filename', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      const validFile = new File(['content'], 'notes.pdf', { type: 'application/pdf' });
+
+      const input = document.getElementById('pdf-upload-0') as HTMLInputElement;
+      await user.upload(input, validFile);
+
+      await waitFor(() => {
+        expect(screen.getByText('notes.pdf')).toBeInTheDocument();
+        expect(screen.getByText(/Used as AI background context/i)).toBeInTheDocument();
+      });
+    });
+
+    it('calls SendData to upload PDF after conversation creation when resource has a PDF', async () => {
+      const user = userEvent.setup();
+      const convWithResources = {
+        ...mockConversationData,
+        resources: [
+          { id: 'res-abc', title: 'My Paper', source: 'speaker', category: 'suggested', participantVisible: true },
+        ],
+      };
+      (Request as jest.Mock).mockImplementation(makeRequestMock(convWithResources));
+
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'My Paper');
+
+      const validFile = new File(['content'], 'paper.pdf', { type: 'application/pdf' });
+      const input = document.getElementById('pdf-upload-0') as HTMLInputElement;
+      await user.upload(input, validFile);
+
+      await waitFor(() => screen.getByText('paper.pdf'));
+
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        expect(SendData).toHaveBeenCalledWith(
+          'resources/conv-resources/res-abc/pdf',
+          null,
+          undefined,
+          expect.objectContaining({ method: 'POST', body: expect.any(FormData) }),
+        );
+      });
+    });
+
+    it('shows a warning when PDF upload fails but still shows EventStatus', async () => {
+      const user = userEvent.setup();
+      const convWithResources = {
+        ...mockConversationData,
+        resources: [
+          { id: 'res-fail', title: 'Fail Paper', source: 'speaker', category: 'suggested', participantVisible: true },
+        ],
+      };
+      (Request as jest.Mock).mockImplementation(makeRequestMock(convWithResources));
+      (SendData as jest.Mock).mockResolvedValue({ error: true });
+
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'Fail Paper');
+
+      const validFile = new File(['content'], 'fail.pdf', { type: 'application/pdf' });
+      const input = document.getElementById('pdf-upload-0') as HTMLInputElement;
+      await user.upload(input, validFile);
+
+      await waitFor(() => screen.getByText('fail.pdf'));
+
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/fail\.pdf/i)).toBeInTheDocument();
+        expect(screen.getByText('Event Status')).toBeInTheDocument();
+      });
+    });
+
+    it('does not call SendData when resource has no PDF attached', async () => {
+      const user = userEvent.setup();
+      const convWithResources = {
+        ...mockConversationData,
+        resources: [
+          { id: 'res-nopdf', title: 'No PDF Paper', source: 'speaker', category: 'suggested', participantVisible: true },
+        ],
+      };
+      (Request as jest.Mock).mockImplementation(makeRequestMock(convWithResources));
+
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+      await navigateToStep5(user);
+
+      await user.type(screen.getByLabelText(/^Title/i), 'No PDF Paper');
+      await user.click(screen.getByRole('button', { name: /create conversation/i }));
+
+      await waitFor(() => screen.getByText('Event Status'));
+      expect(SendData).not.toHaveBeenCalled();
     });
   });
 
@@ -1830,6 +2279,7 @@ describe('EventCreationForm Component', () => {
       await user.click(screen.getByRole('button', { name: /next/i }));
 
       await waitFor(() => screen.getByText('About the Speakers'));
+      // Step 4 — stay here for speaker/moderator interaction before optionally proceeding
     };
 
     beforeEach(() => {
@@ -1888,6 +2338,8 @@ describe('EventCreationForm Component', () => {
       const alternateNameInput = screen.getByLabelText(/Alternate Name/i);
       await user.type(alternateNameInput, 'Jon');
 
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
       await user.click(screen.getByRole('button', { name: /create conversation/i }));
 
       await waitFor(() => {

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -38,7 +38,7 @@ import { createConversationFromData, Api, SendData } from '../utils/Helpers';
 import SessionManager from '../utils/SessionManager';
 import { NewTopicForm, NewTopicFormValues } from './NewTopicForm';
 
-const steps = ['Event Details', 'Conversation Setup', 'Configuration', 'Moderators & Speakers'];
+const steps = ['Event Details', 'Conversation Setup', 'Configuration', 'Speakers', 'Resources'];
 
 /**
  * EventCreationForm component
@@ -79,7 +79,9 @@ export const EventCreationForm: React.FC = ({}) => {
 
   const [dynamicPropertyValues, setDynamicPropertyValues] = useState<Record<string, any>>({});
   const [formSubmitted, setFormSubmitted] = useState(false);
+  const [formSubmitting, setFormSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
+  const [pdfUploadWarnings, setPdfUploadWarnings] = useState<string[]>([]);
   const [conversationData, setConversationData] = useState<Conversation | null>(null);
 
   const [formGroupsErrors, setFormGroupsErrors] = useState({
@@ -89,13 +91,56 @@ export const EventCreationForm: React.FC = ({}) => {
   const [platformsPreviouslyChecked, setPlatformsPreviouslyChecked] = useState(false);
 
   // Moderators and Speakers state
-  const [moderators, setModerators] = useState<Array<{ name: string; bio: string; alternateName?: string }>>([
-    { name: '', bio: '' },
-  ]);
-  const [speakers, setSpeakers] = useState<Array<{ name: string; bio: string; alternateName?: string }>>([
-    { name: '', bio: '' },
-  ]);
+  const emptySpeaker = () => ({ name: '', bio: '', alternateName: undefined as string | undefined });
+  const emptyModerator = () => ({ name: '', bio: '', alternateName: undefined as string | undefined });
+
+  const [moderators, setModerators] = useState([emptyModerator()]);
+  const [speakers, setSpeakers] = useState([emptySpeaker()]);
   const [showModerators, setShowModerators] = useState<boolean>(false);
+
+  // Reading & Resources state
+  const emptyResource = () => ({
+    title: '',
+    authors: '',
+    year: '',
+    url: '',
+    description: '',
+    citation: '',
+    pdf: undefined as File | undefined,
+    required: false,
+    participantVisible: true,
+  });
+
+  const [resources, setResources] = useState<ReturnType<typeof emptyResource>[]>([emptyResource()]);
+  const [pdfDragOver, setPdfDragOver] = useState<number | null>(null);
+
+  const addResource = () => setResources((prev) => [...prev, emptyResource()]);
+
+  const updateResource = (
+    index: number,
+    field: keyof ReturnType<typeof emptyResource>,
+    value: string | boolean | File | undefined,
+  ) => {
+    setResources((prev) => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const removeResource = (index: number) => {
+    setResources((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const PDF_MAX_BYTES = 20 * 1024 * 1024;
+
+  const attachPdf = (index: number, file: File) => {
+    if (file.size > PDF_MAX_BYTES) {
+      setFormError(`"${file.name}" exceeds the 20 MB limit and cannot be attached.`);
+      return;
+    }
+    updateResource(index, 'pdf', file);
+  };
 
   // Topic (Event Series) state
   const [topicMode, setTopicMode] = useState<'existing' | 'new'>('existing');
@@ -340,7 +385,7 @@ export const EventCreationForm: React.FC = ({}) => {
 
   // Moderator management functions
   const addModerator = () => {
-    setModerators([...moderators, { name: '', bio: '' }]);
+    setModerators([...moderators, emptyModerator()]);
   };
 
   const removeModerator = (index: number) => {
@@ -357,7 +402,7 @@ export const EventCreationForm: React.FC = ({}) => {
 
   // Speaker management functions
   const addSpeaker = () => {
-    setSpeakers([...speakers, { name: '', bio: '' }]);
+    setSpeakers([...speakers, emptySpeaker()]);
   };
 
   const removeSpeaker = (index: number) => {
@@ -729,15 +774,10 @@ export const EventCreationForm: React.FC = ({}) => {
   };
 
   const handleNext = () => {
-    if (activeStep === 0 && !validateStep1()) {
-      return;
-    }
-    if (activeStep === 1 && !validateStep2()) {
-      return;
-    }
-    if (activeStep === 2 && !validateStep3()) {
-      return;
-    }
+    if (activeStep === 0 && !validateStep1()) return;
+    if (activeStep === 1 && !validateStep2()) return;
+    if (activeStep === 2 && !validateStep3()) return;
+    // Steps 3 and 4 have no required fields — always advance
     setActiveStep((prevStep) => prevStep + 1);
   };
 
@@ -780,6 +820,26 @@ export const EventCreationForm: React.FC = ({}) => {
     const validModerators = showModerators ? moderators.filter((m) => m.name.trim() !== '' || m.bio.trim() !== '') : [];
     const validSpeakers = speakers.filter((s) => s.name.trim() !== '' || s.bio.trim() !== '');
 
+    // Build resources payload — exclude entries with no title
+    const validResources = resources
+      .filter((r) => r.title.trim() !== '')
+      .map((r) => ({
+        source: 'speaker' as const,
+        category: r.required ? ('required' as const) : ('suggested' as const),
+        title: r.title.trim(),
+        ...(r.authors.trim() && {
+          authors: r.authors
+            .split(',')
+            .map((a) => a.trim())
+            .filter(Boolean),
+        }),
+        ...(r.year.trim() && { year: r.year.trim() }),
+        ...(r.url.trim() && { url: r.url.trim() }),
+        ...(r.description.trim() && { description: r.description.trim() }),
+        ...(r.citation.trim() && { citation: r.citation.trim() }),
+        participantVisible: r.participantVisible,
+      }));
+
     let body: any = {
       name: eventName,
       ...(eventDescription && { description: eventDescription }),
@@ -790,6 +850,7 @@ export const EventCreationForm: React.FC = ({}) => {
       topicId,
       ...(validModerators.length > 0 && { moderators: validModerators }),
       ...(validSpeakers.length > 0 && { presenters: validSpeakers }),
+      ...(validResources.length > 0 && { resources: validResources }),
     };
 
     // Dynamically build properties based on conversationType schema
@@ -838,16 +899,52 @@ export const EventCreationForm: React.FC = ({}) => {
       ...(features.length > 0 && { features }),
     };
 
+    setFormSubmitting(true);
     Request('conversations/from-type', body)
-      .then((data) => {
+      .then(async (data) => {
         if (!data) {
           setFormError('Failed to send data. Please try again.');
+          setFormSubmitting(false);
           return;
         }
         if ('error' in data) {
           setFormError(data.message?.message || 'Failed to create conversation.');
+          setFormSubmitting(false);
           return;
         }
+
+        // Upload PDFs for any resources that have one attached
+        const conversationId = data.id as string;
+        const responseResources: components['schemas']['Resource'][] = data.resources ?? [];
+        const resourcesWithPdf = resources
+          .filter((r) => r.title.trim() !== '' && r.pdf)
+          .flatMap((r) => {
+            const match = responseResources.find((res) => res.title === r.title.trim());
+            return match?.id ? [{ pdf: r.pdf as File, resourceId: match.id }] : [];
+          });
+
+        if (resourcesWithPdf.length > 0) {
+          const uploadResults = await Promise.allSettled(
+            resourcesWithPdf.map(({ pdf, resourceId }) => {
+              const formData = new FormData();
+              formData.append('pdf', pdf);
+              return SendData(`resources/${conversationId}/${resourceId}/pdf`, null, undefined, {
+                method: 'POST',
+                body: formData,
+              });
+            }),
+          );
+
+          const failures = uploadResults
+            .map((result, i) => ({ result, name: resourcesWithPdf[i].pdf.name }))
+            .filter(({ result }) => result.status === 'rejected' || (result.status === 'fulfilled' && result.value?.error))
+            .map(({ name }) => name);
+
+          if (failures.length > 0) {
+            setPdfUploadWarnings(failures);
+          }
+        }
+
         createConversationFromData(data).then((conversation) => {
           setConversationData(conversation);
           setFormSubmitted(true);
@@ -856,11 +953,22 @@ export const EventCreationForm: React.FC = ({}) => {
       .catch((error) => {
         console.error('Error sending data:', error);
         setFormError(`Failed to send data. (${error.message})`);
+        setFormSubmitting(false);
       });
   };
 
   if (formSubmitted && conversationData) {
-    return <EventStatus conversationData={conversationData} />;
+    return (
+      <>
+        {pdfUploadWarnings.length > 0 && (
+          <Alert severity="warning" sx={{ maxWidth: 800, mx: 'auto', mt: 4 }}>
+            The following PDFs could not be uploaded and will not be available as AI context:{' '}
+            <strong>{pdfUploadWarnings.join(', ')}</strong>. You can retry by editing the event.
+          </Alert>
+        )}
+        <EventStatus conversationData={conversationData} />
+      </>
+    );
   }
 
   return (
@@ -1399,7 +1507,7 @@ export const EventCreationForm: React.FC = ({}) => {
                       size="small"
                       onClick={() => {
                         setShowModerators(false);
-                        setModerators([{ name: '', bio: '' }]);
+                        setModerators([emptyModerator()]);
                       }}
                     >
                       Remove All
@@ -1493,6 +1601,246 @@ export const EventCreationForm: React.FC = ({}) => {
             </Box>
           )}
 
+          {/* Step 5: Reading & Resources */}
+          {activeStep === 4 && (
+            <Box>
+              <Typography variant="h5" component="h2" gutterBottom>
+                Reading & Resources
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                Add papers, articles, or links that attendees and the AI should know about (optional). Only the title is
+                required — fill in what you have. To make a resource available as background context for the AI, attach a PDF
+                — the AI will not have access to linked URLs alone.
+              </Typography>
+
+              {resources.length === 0 && (
+                <Box
+                  sx={{
+                    p: 2,
+                    border: '1px dashed rgba(0,0,0,0.2)',
+                    borderRadius: 1,
+                    textAlign: 'center',
+                    mb: 2,
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    No resources added yet.
+                  </Typography>
+                </Box>
+              )}
+
+              {resources.map((resource, index) => (
+                <Box
+                  key={index}
+                  sx={{
+                    mb: 2,
+                    p: 2,
+                    border: '1px solid rgba(0,0,0,0.12)',
+                    borderRadius: 1,
+                  }}
+                >
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Resource {index + 1}
+                    </Typography>
+                    {resources.length > 1 && (
+                      <Button size="small" color="error" onClick={() => removeResource(index)}>
+                        Remove
+                      </Button>
+                    )}
+                  </Box>
+
+                  <TextField
+                    label="Title"
+                    value={resource.title}
+                    onChange={(e) => updateResource(index, 'title', e.target.value)}
+                    fullWidth
+                    variant="outlined"
+                    margin="dense"
+                    required
+                    placeholder="e.g. Attention Is All You Need"
+                  />
+                  <TextField
+                    label="URL"
+                    value={resource.url}
+                    onChange={(e) => updateResource(index, 'url', e.target.value)}
+                    fullWidth
+                    variant="outlined"
+                    margin="dense"
+                    placeholder="https://..."
+                  />
+                  <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+                    <TextField
+                      label="Authors"
+                      value={resource.authors}
+                      onChange={(e) => updateResource(index, 'authors', e.target.value)}
+                      variant="outlined"
+                      margin="dense"
+                      placeholder="Jane Smith, John Doe…"
+                      helperText="Comma-separated. Use First Last order."
+                      sx={{ flex: 1 }}
+                    />
+                    <TextField
+                      label="Year"
+                      value={resource.year}
+                      onChange={(e) => updateResource(index, 'year', e.target.value)}
+                      variant="outlined"
+                      margin="dense"
+                      placeholder="2024"
+                      sx={{ width: 100 }}
+                    />
+                  </Box>
+                  <TextField
+                    label="Citation (optional)"
+                    value={resource.citation}
+                    onChange={(e) => updateResource(index, 'citation', e.target.value)}
+                    fullWidth
+                    variant="outlined"
+                    margin="dense"
+                    placeholder="e.g. Vaswani et al. (2017). Attention is all you need. NeurIPS."
+                  />
+                  <TextField
+                    label="Description"
+                    value={resource.description}
+                    onChange={(e) => updateResource(index, 'description', e.target.value)}
+                    fullWidth
+                    variant="outlined"
+                    margin="dense"
+                    multiline
+                    rows={3}
+                    helperText="Express why this reading matters for this session. This is shown to attendees."
+                    placeholder="Why is this reading relevant to the session?"
+                  />
+
+                  {/* PDF attachment */}
+                  <Box sx={{ mt: 1.5, mb: 0.5 }}>
+                    <input
+                      type="file"
+                      accept="application/pdf"
+                      style={{ display: 'none' }}
+                      id={`pdf-upload-${index}`}
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) attachPdf(index, file);
+                        e.target.value = '';
+                      }}
+                    />
+                    {resource.pdf ? (
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                          p: 1.5,
+                          border: '1px solid rgba(0,0,0,0.12)',
+                          borderRadius: 1,
+                        }}
+                      >
+                        <Box sx={{ flex: 1 }}>
+                          <Typography variant="body2" fontWeight={500}>
+                            {resource.pdf.name}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {(resource.pdf.size / 1024 / 1024).toFixed(1)} MB · Used as AI background context
+                          </Typography>
+                        </Box>
+                        <Button size="small" onClick={() => document.getElementById(`pdf-upload-${index}`)?.click()}>
+                          Replace
+                        </Button>
+                        <Button size="small" color="error" onClick={() => updateResource(index, 'pdf', undefined)}>
+                          Remove
+                        </Button>
+                      </Box>
+                    ) : (
+                      <Box
+                        onClick={() => document.getElementById(`pdf-upload-${index}`)?.click()}
+                        onDragOver={(e) => {
+                          e.preventDefault();
+                          setPdfDragOver(index);
+                        }}
+                        onDragLeave={() => setPdfDragOver(null)}
+                        onDrop={(e) => {
+                          e.preventDefault();
+                          setPdfDragOver(null);
+                          const file = e.dataTransfer.files?.[0];
+                          if (file?.type === 'application/pdf') {
+                            attachPdf(index, file);
+                          }
+                        }}
+                        sx={{
+                          p: 2,
+                          border: '1px dashed',
+                          borderColor: pdfDragOver === index ? 'primary.main' : 'rgba(0,0,0,0.2)',
+                          borderRadius: 1,
+                          textAlign: 'center',
+                          cursor: 'pointer',
+                          bgcolor: pdfDragOver === index ? 'action.hover' : 'transparent',
+                          transition: 'border-color 0.15s, background-color 0.15s',
+                          '&:hover': { borderColor: 'primary.main', bgcolor: 'action.hover' },
+                        }}
+                      >
+                        <Typography variant="body2" color="text.secondary">
+                          Drop a PDF here or <strong>click to browse</strong>
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          Required for AI background context · Max 20 MB
+                        </Typography>
+                      </Box>
+                    )}
+                  </Box>
+
+                  <Box sx={{ display: 'flex', gap: 3, mt: 1.5, flexWrap: 'wrap' }}>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={resource.participantVisible}
+                          onChange={(e) => updateResource(index, 'participantVisible', e.target.checked)}
+                        />
+                      }
+                      label={
+                        <Box>
+                          <Typography variant="body2" fontWeight={500}>
+                            Show to attendees
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            Appears in the Resources tab
+                          </Typography>
+                        </Box>
+                      }
+                    />
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={resource.required}
+                          disabled={!resource.participantVisible}
+                          onChange={(e) => updateResource(index, 'required', e.target.checked)}
+                        />
+                      }
+                      label={
+                        <Box>
+                          <Typography
+                            variant="body2"
+                            fontWeight={500}
+                            color={!resource.participantVisible ? 'text.disabled' : undefined}
+                          >
+                            Mark as required
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            Shown in &quot;Required Reading&quot; section
+                          </Typography>
+                        </Box>
+                      }
+                    />
+                  </Box>
+                </Box>
+              ))}
+
+              <Button variant="outlined" size="small" onClick={addResource}>
+                + Add Resource
+              </Button>
+            </Box>
+          )}
+
           {/* Navigation Buttons */}
           <Box sx={{ mt: 4, display: 'flex', justifyContent: 'space-between' }}>
             <Button
@@ -1509,6 +1857,7 @@ export const EventCreationForm: React.FC = ({}) => {
               <Button
                 type="button"
                 variant="contained"
+                disabled={formSubmitting}
                 onClick={(e) => {
                   e.preventDefault();
                   if (formRef.current) sendData(new FormData(formRef.current));
@@ -1518,7 +1867,14 @@ export const EventCreationForm: React.FC = ({}) => {
                   fontSize: { xs: '0.75rem', sm: '0.875rem' },
                 }}
               >
-                Create Conversation
+                {formSubmitting ? (
+                  <>
+                    <CircularProgress size={16} color="inherit" sx={{ mr: 1 }} />
+                    Creating…
+                  </>
+                ) : (
+                  'Create Conversation'
+                )}
               </Button>
             ) : (
               <Button

--- a/components/ResourcesPanel.tsx
+++ b/components/ResourcesPanel.tsx
@@ -62,8 +62,9 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
   onMarkReadingsAsSeen,
   newResourceIds,
 }) => {
-  const suggestedResources = resources.filter((r) => r.category === 'suggested');
-  const requiredResources = resources.filter((r) => r.category === 'required');
+  const visibleResources = resources.filter((r) => r.participantVisible !== false);
+  const suggestedResources = visibleResources.filter((r) => r.category === 'suggested');
+  const requiredResources = visibleResources.filter((r) => r.category === 'required');
 
   // Track which categories are expanded
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());


### PR DESCRIPTION
## What is in this PR?

Adds a Step 5 to the Event Creation form to add background/required readings

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

-feat: add resources to event creation form
- fix: do not show resources in resources tab where participantVisible is false

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [x] Test in conjunction with BE PR https://github.com/berkmancenter/llm_engine/pull/133
- [x] Create an event and add some readings on Step 5 (go for a variety - one with a PDF upload, one without, some visible to participant, some required, some with URL, some author/year, etc)
- [x] Verify that any participant-visible readings can be seen on the Resources tab, under either the required or optional headings, depending. If you specified a description, author, or year that should be visible. Where URL specified, title should be clickable link
- [x] Ask Berkie a question that requires it consult any PDFs you uploaded (also check logs to see if getting the background reading as context)
- [x] Create another event without specifying any readings and ensure creation does not fail



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
