### PR TITLE
feat: add pseudonym info popover with description and optional fun fact

### DIFF
--- a/__tests__/components/MessageInput.Test.tsx
+++ b/__tests__/components/MessageInput.Test.tsx
@@ -432,6 +432,62 @@ describe('MessageInput Component', () => {
     });
   });
 
+  describe('Pseudonym Info Popover', () => {
+    it('renders the info button next to the pseudonym', () => {
+      render(<MessageInput {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: 'Pseudonym info' })).toBeInTheDocument();
+    });
+
+    it('opens popover when info button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<MessageInput {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Pseudonym info' }));
+
+      expect(screen.getByText(/who are you today/i)).toBeInTheDocument();
+      expect(screen.getByText(/not even the ai knows your real name/i)).toBeInTheDocument();
+    });
+
+    it('does not show fun fact section when pseudonymFunFact is not provided', async () => {
+      const user = userEvent.setup();
+      render(<MessageInput {...defaultProps} />);
+
+      await user.click(screen.getByRole('button', { name: 'Pseudonym info' }));
+
+      expect(screen.queryByText(/fun fact/i)).not.toBeInTheDocument();
+    });
+
+    it('shows fun fact when pseudonymFunFact is provided', async () => {
+      const user = userEvent.setup();
+      render(
+        <MessageInput
+          {...defaultProps}
+          pseudonymFunFact="The name 'Velvet Fox' is inspired by a real subspecies native to the Pacific Northwest."
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Pseudonym info' }));
+
+      expect(screen.getByText(/fun fact/i)).toBeInTheDocument();
+      expect(screen.getByText(/Velvet Fox/i)).toBeInTheDocument();
+    });
+
+    it('closes popover when clicking away', async () => {
+      const user = userEvent.setup();
+      render(<MessageInput {...defaultProps} pseudonymFunFact="Some fun fact." />);
+
+      await user.click(screen.getByRole('button', { name: 'Pseudonym info' }));
+      expect(screen.getByText(/who are you today/i)).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.queryByText(/who are you today/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('Multiple Messages', () => {
     it('allows typing and sending multiple messages', async () => {
       const user = userEvent.setup();

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -234,6 +234,79 @@ describe('EventAssistantRoom', () => {
     });
   });
 
+  describe('pseudonym fun fact', () => {
+    it('fetches user data using userId on mount', async () => {
+      (RetrieveData as jest.Mock).mockImplementation((url: string) => {
+        if (url === 'users/user/user-123') {
+          return Promise.resolve({
+            pseudonyms: [
+              { active: true, pseudonym: 'test-pseudonym', funFact: "Foxes use the Earth's magnetic field to hunt." },
+            ],
+          });
+        }
+        return Promise.resolve({ agents: [{ id: 'agent-123', agentType: 'eventAssistant' }] });
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={'guest'} />);
+      });
+
+      await waitFor(() => {
+        expect(RetrieveData).toHaveBeenCalledWith('users/user/user-123', 'mock-access-token');
+      });
+    });
+
+    it('does not fetch user data when userId is null', async () => {
+      mockUseSessionJoin.mockReturnValue({
+        socket: mockSocket,
+        pseudonym: 'test-pseudonym',
+        userId: null,
+        isConnected: true,
+        errorMessage: null,
+      });
+
+      await act(async () => {
+        render(<EventAssistantRoom authType={'guest'} />);
+      });
+
+      await waitFor(() => {
+        expect(RetrieveData).not.toHaveBeenCalledWith(expect.stringContaining('users/user/'), expect.anything());
+      });
+    });
+
+    it('passes fun fact to chat panel when active pseudonym has funFact', async () => {
+      (RetrieveData as jest.Mock).mockImplementation((url: string) => {
+        if (url === 'users/user/user-123') {
+          return Promise.resolve({
+            pseudonyms: [
+              { active: true, pseudonym: 'test-pseudonym', funFact: "Foxes use the Earth's magnetic field to hunt." },
+            ],
+          });
+        }
+        return Promise.resolve({ agents: [{ id: 'agent-123', agentType: 'eventAssistant' }] });
+      });
+
+      await act(async () => {
+        render(
+          <ConversationTypeProvider>
+            <EventAssistantRoom authType={'guest'} />
+          </ConversationTypeProvider>,
+        );
+      });
+
+      // Open the info popover
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Pseudonym info' })).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Pseudonym info' }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Foxes use the Earth/i)).toBeInTheDocument();
+      });
+    });
+  });
+
   it('fetches conversation data when router is ready', async () => {
     await act(async () => {
       render(<EventAssistantRoom authType={'guest'} />);

--- a/components/AssistantChatPanel.tsx
+++ b/components/AssistantChatPanel.tsx
@@ -21,6 +21,7 @@ import { ThreadPanel } from './ThreadPanel';
 interface AssistantChatPanelProps {
   messages: PseudonymousMessage[];
   pseudonym: string | null;
+  pseudonymFunFact?: string;
   waitingForResponse: boolean;
   controlledMode: ControlledInputConfig | null;
   slashCommands: SlashCommand[];
@@ -41,6 +42,7 @@ interface AssistantChatPanelProps {
 export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
   messages,
   pseudonym,
+  pseudonymFunFact,
   waitingForResponse,
   controlledMode,
   slashCommands,
@@ -379,6 +381,7 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
           ) : (
             <MessageInput
               pseudonym={pseudonym}
+              pseudonymFunFact={pseudonymFunFact}
               enhancers={enhancers}
               onSendMessage={onSendMessage}
               waitingForResponse={waitingForResponse}

--- a/components/GroupChatPanel.tsx
+++ b/components/GroupChatPanel.tsx
@@ -38,6 +38,7 @@ const renderAssistantMessage = (text: string): React.ReactNode => {
 interface GroupChatPanelProps {
   messages: PseudonymousMessage[];
   pseudonym: string | null;
+  pseudonymFunFact?: string;
   eventName?: string;
   botName?: string;
   inputValue?: string;
@@ -54,6 +55,7 @@ interface GroupChatPanelProps {
 export const GroupChatPanel: FC<GroupChatPanelProps> = ({
   messages,
   pseudonym,
+  pseudonymFunFact,
   eventName,
   botName = 'Berkie',
   inputValue,
@@ -338,6 +340,7 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
         <div ref={messageInputRef} className="flex-shrink-0">
           <MessageInput
             pseudonym={pseudonym}
+            pseudonymFunFact={pseudonymFunFact}
             enhancers={enhancers}
             onSendMessage={onSendMessage}
             waitingForResponse={waitingForResponse && !waitingForThreadedReply}

--- a/components/MessageInput.tsx
+++ b/components/MessageInput.tsx
@@ -1,6 +1,6 @@
 import { FC, useState, useRef, KeyboardEvent, ChangeEvent, useEffect, useCallback } from 'react';
-import { Box, IconButton, InputAdornment, TextField } from '@mui/material';
-import { Send, Close } from '@mui/icons-material';
+import { Box, IconButton, InputAdornment, TextField, Popover, Typography } from '@mui/material';
+import { Send, Close, InfoOutlined } from '@mui/icons-material';
 import { ControlledInputConfig } from '../types.internal';
 import { ActiveEnhancerState, InputEnhancer } from '../types/inputEnhancer';
 import { GenericEnhancerMenu } from './GenericEnhancerMenu';
@@ -8,6 +8,7 @@ import { getAvatarStyle } from '../utils/avatarUtils';
 
 interface MessageInputProps {
   pseudonym: string | null;
+  pseudonymFunFact?: string;
   enhancers: InputEnhancer<any>[];
   onSendMessage: (message: string) => void;
   waitingForResponse: boolean;
@@ -20,6 +21,7 @@ interface MessageInputProps {
 
 export const MessageInput: FC<MessageInputProps> = ({
   pseudonym,
+  pseudonymFunFact,
   enhancers,
   onSendMessage,
   waitingForResponse,
@@ -35,6 +37,7 @@ export const MessageInput: FC<MessageInputProps> = ({
   const setCurrentMessage = isControlled ? onInputChange : setInternalValue;
 
   const [activeEnhancer, setActiveEnhancer] = useState<ActiveEnhancerState<any> | null>(null);
+  const [pseudonymInfoAnchor, setPseudonymInfoAnchor] = useState<HTMLButtonElement | null>(null);
 
   const messageInputRef = useRef<HTMLInputElement>(null);
   const enterUsedForCommandRef = useRef(false);
@@ -203,8 +206,16 @@ export const MessageInput: FC<MessageInputProps> = ({
                 backgroundColor: getAvatarStyle(pseudonym, true).avatarBg,
               }}
             >
-              <span className="uppercase">
+              <span className="uppercase flex items-center gap-1">
                 Writing as {pseudonym}
+                <IconButton
+                  size="small"
+                  onClick={(e) => setPseudonymInfoAnchor(e.currentTarget)}
+                  sx={{ padding: '2px', verticalAlign: 'middle' }}
+                  aria-label="Pseudonym info"
+                >
+                  <InfoOutlined sx={{ fontSize: 16 }} />
+                </IconButton>
                 {controlledMode && (
                   <span className="normal-case">
                     {' • '}
@@ -212,6 +223,31 @@ export const MessageInput: FC<MessageInputProps> = ({
                   </span>
                 )}
               </span>
+              <Popover
+                open={Boolean(pseudonymInfoAnchor)}
+                anchorEl={pseudonymInfoAnchor}
+                onClose={() => setPseudonymInfoAnchor(null)}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                slotProps={{ paper: { sx: { maxWidth: 300, p: 2 } } }}
+              >
+                <Typography variant="subtitle2" fontWeight="bold" gutterBottom>
+                  Who are you today?
+                </Typography>
+                <Typography variant="body2" color="text.secondary" gutterBottom>
+                  To protect your privacy, your identity is hidden behind this pseudonym. Not even the AI knows your real
+                  name.
+                </Typography>
+                {pseudonymFunFact && (
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', mt: 1, pt: 1, borderTop: '1px solid', borderColor: 'divider' }}
+                  >
+                    <strong>Fun fact:</strong> {pseudonymFunFact}
+                  </Typography>
+                )}
+              </Popover>
               {controlledMode && (
                 <IconButton size="small" onClick={onExitControlledMode} sx={{ padding: '4px' }}>
                   <Close fontSize="small" />

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -136,6 +136,18 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
   // Use custom hook for session joining
   const { socket, pseudonym, userId, isConnected, errorMessage: sessionError, lastReconnectTime } = useSessionJoin();
 
+  const [pseudonymFunFact, setPseudonymFunFact] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!userId) return;
+    RetrieveData(`users/user/${userId}`, Api.get().getAccessToken()).then((user) => {
+      if (user && !('error' in user)) {
+        const activePseudonym = user.pseudonyms?.find((p: any) => p.active);
+        if (activePseudonym?.funFact) setPseudonymFunFact(activePseudonym.funFact);
+      }
+    });
+  }, [userId]);
+
   // Combine session and local errors
   const errorMessage = sessionError || localError;
 
@@ -795,6 +807,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
                         <GroupChatPanel
                           messages={chatMessages}
                           pseudonym={pseudonym}
+                          pseudonymFunFact={pseudonymFunFact}
                           eventName={eventName}
                           botName={botName}
                           inputValue={chatInputValue}
@@ -833,6 +846,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
                         <AssistantChatPanel
                           messages={assistantMessages}
                           pseudonym={pseudonym}
+                          pseudonymFunFact={pseudonymFunFact}
                           waitingForResponse={waitingForResponse}
                           controlledMode={controlledMode}
                           slashCommands={slashCommands}


### PR DESCRIPTION
## What is in this PR?

We are removing the pseudonym fun fact from the intro message, so this PR adds an info popover to the pseudonym part of the input box that will display it if set, along with a bit of context as to why the pseudonym is there.

## Changes in the codebase

<!-- This is technical. Here is where you can be more focused on the engineering side of your solution. Include information about the functionality they are adding or modifying, as well as any refactoring or improvement of existing code. -->

assistant retrieves full User object using userId from session. passes the user's active pseudonym fun fact (if present) to the group and private chat channels for display in the MessageInput area.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Test in conjunction with BE PR https://github.com/berkmancenter/llm_engine/pull/146
- [ ] Create an EA conversation 
- [ ] Open participant page. Will likely use an existing session/pseudonym. The info popover should NOT have a fun fact in this case
- [ ] Clear cookie to generate a new pseudonym. Verify that there IS a fun fact at the bottom of the popover



## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
