### PR TITLE
Fix: message input is cleared even if not sent

### DIFF
--- a/__tests__/components/MessageInput.Test.tsx
+++ b/__tests__/components/MessageInput.Test.tsx
@@ -8,7 +8,7 @@ import { SlashCommand, createSlashCommandEnhancer } from '../../components/enhan
 Element.prototype.scrollIntoView = jest.fn();
 
 describe('MessageInput Component', () => {
-  const mockOnSendMessage = jest.fn();
+  const mockOnSendMessage = jest.fn(() => Promise.resolve(true));
   const mockOnExitControlledMode = jest.fn();
 
   const mockSlashCommands: SlashCommand[] = [
@@ -114,7 +114,7 @@ describe('MessageInput Component', () => {
       expect(mockOnSendMessage).toHaveBeenCalledWith('Test message');
     });
 
-    it('clears input after sending message', async () => {
+    it('clears input after sending message successfully', async () => {
       const user = userEvent.setup();
       render(<MessageInput {...defaultProps} />);
 
@@ -127,6 +127,25 @@ describe('MessageInput Component', () => {
       await waitFor(() => {
         expect(input.value).toBe('');
       });
+    });
+
+    it('does not clear input after sending message unsuccessfully', async () => {
+      const user = userEvent.setup();
+      defaultProps.onSendMessage = jest.fn(() => Promise.resolve(false));
+      render(<MessageInput {...defaultProps} />);
+
+      const input = screen.getByPlaceholderText('Enter your message here') as HTMLInputElement;
+      const sendButton = screen.getByLabelText('send message');
+
+      await user.type(input, 'Test message');
+      await user.click(sendButton);
+
+      await waitFor(() => {
+        expect(input.value).toBe('Test message');
+      });
+
+      // Reset props
+      defaultProps.onSendMessage = mockOnSendMessage;
     });
 
     it('does not send empty message', async () => {

--- a/components/AssistantChatPanel.tsx
+++ b/components/AssistantChatPanel.tsx
@@ -29,7 +29,7 @@ interface AssistantChatPanelProps {
   botName: string;
   inputValue?: string;
   onInputChange?: (value: string) => void;
-  onSendMessage: (message: string, parentMessageId?: string) => void;
+  onSendMessage: (message: string, parentMessageId?: string) => Promise<boolean>;
   onExitControlledMode: () => void;
   onPromptSelect: (prompt: string, promptMessageId?: string) => void;
   userId: string | null;
@@ -381,7 +381,6 @@ export const AssistantChatPanel: FC<AssistantChatPanelProps> = ({
           ) : (
             <MessageInput
               pseudonym={pseudonym}
-              pseudonymFunFact={pseudonymFunFact}
               enhancers={enhancers}
               onSendMessage={onSendMessage}
               waitingForResponse={waitingForResponse}

--- a/components/GroupChatPanel.tsx
+++ b/components/GroupChatPanel.tsx
@@ -36,20 +36,33 @@ const renderAssistantMessage = (text: string): React.ReactNode => {
 };
 
 interface GroupChatPanelProps {
+  /** The list of messages to display in the chat panel */
   messages: PseudonymousMessage[];
+  /** The pseudonym of the current user */
   pseudonym: string | null;
   pseudonymFunFact?: string;
+  /** The name of the event, if applicable */
   eventName?: string;
+  /** The name of the bot, if applicable */
   botName?: string;
+  /** The current value of the input in controlled mode */
   inputValue?: string;
-  onInputChange?: (value: string) => void;
-  onSendMessage: (message: string, parentMessageId?: string) => void;
+  /** Configuration for controlled input mode */
   controlledMode?: ControlledInputConfig | null;
-  onExitControlledMode?: () => void;
+  /** Configuration for feedback */
   feedbackConfig?: FeedbackConfig;
+  /** Set of message IDs with unread replies */
   messagesWithUnreadReplies?: Set<string>;
-  onMarkAsRead?: (messageId: string) => void;
+  /** Whether the chat is waiting for a response */
   waitingForResponse?: boolean;
+  /** Callback when exiting controlled input mode */
+  onExitControlledMode?: () => void;
+  /** Callback when marking a message as read */
+  onMarkAsRead?: (messageId: string) => void;
+  /** Callback when the input value changes in controlled mode */
+  onInputChange?: (value: string) => void;
+  /** Callback when a message is sent; should return true if the message was successfully sent */
+  onSendMessage: (message: string, parentMessageId?: string) => Promise<boolean>;
 }
 
 export const GroupChatPanel: FC<GroupChatPanelProps> = ({
@@ -59,14 +72,14 @@ export const GroupChatPanel: FC<GroupChatPanelProps> = ({
   eventName,
   botName = 'Berkie',
   inputValue,
-  onInputChange,
-  onSendMessage,
   controlledMode,
-  onExitControlledMode,
   feedbackConfig,
   messagesWithUnreadReplies = new Set(),
-  onMarkAsRead,
   waitingForResponse = false,
+  onExitControlledMode,
+  onInputChange,
+  onMarkAsRead,
+  onSendMessage,
 }) => {
   // State for tracking which thread is open in split view
   const [selectedThreadId, setSelectedThreadId] = React.useState<string | null>(null);

--- a/components/MessageInput.tsx
+++ b/components/MessageInput.tsx
@@ -7,16 +7,24 @@ import { GenericEnhancerMenu } from './GenericEnhancerMenu';
 import { getAvatarStyle } from '../utils/avatarUtils';
 
 interface MessageInputProps {
+  /** The pseudonym of the user */
   pseudonym: string | null;
   pseudonymFunFact?: string;
+  /** List of input enhancers */
   enhancers: InputEnhancer<any>[];
-  onSendMessage: (message: string) => void;
+  /** Whether the input is waiting for a response */
   waitingForResponse: boolean;
   controlledMode: ControlledInputConfig | null;
-  onExitControlledMode: () => void;
+  /** The current value of the input in controlled mode */
   inputValue?: string;
-  onInputChange?: (value: string) => void;
+  /** Whether to disable the input while waiting for a response */
   disableWhileWaiting?: boolean;
+  /** Callback when a message is sent; should return true if the message was successfully sent */
+  onSendMessage: (message: string) => Promise<boolean>;
+  /** Callback when exiting controlled input mode */
+  onExitControlledMode: () => void;
+  /** Callback when the input value changes in controlled mode */
+  onInputChange?: (value: string) => void;
 }
 
 export const MessageInput: FC<MessageInputProps> = ({
@@ -109,11 +117,11 @@ export const MessageInput: FC<MessageInputProps> = ({
   };
 
   /** Send message */
-  const handleSend = () => {
+  const handleSend = async () => {
     const canSend = disableWhileWaiting ? !waitingForResponse : true;
     if (currentMessage && currentMessage.length > 0 && canSend) {
-      onSendMessage(currentMessage);
-      setCurrentMessage('');
+      const success = await onSendMessage(currentMessage);
+      if (success) setCurrentMessage('');
     }
   };
 

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -663,7 +663,11 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         ...(messageSource === 'promptResponse' && promptQuestionId && { answersPrompt: promptQuestionId }),
       });
 
-      if (response.error) return false;
+      if (response.error) {
+        setWaitingForResponse(false);
+
+        return false;
+      }
 
       // Auto-exit controlled mode after sending
       if (controlledMode) {

--- a/pages/assistant.tsx
+++ b/pages/assistant.tsx
@@ -608,7 +608,7 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
     messageSource: 'message' | 'promptResponse' = 'message',
     promptQuestionId?: string,
   ) {
-    if (!Api.get().GetTokens() || !message) return;
+    if (!Api.get().GetTokens() || !message) return false;
 
     // Use different channel based on active tab
     // When in transcript view, default to assistant channel for sending
@@ -653,19 +653,27 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
         setWaitingForChatResponse(true);
       }
     }
+    try {
+      const response = await SendData('messages', {
+        body: finalMessage,
+        bodyType: 'text',
+        conversation: router.query.conversationId,
+        channels,
+        ...(parentMessageId !== undefined && { parentMessage: parentMessageId }),
+        ...(messageSource === 'promptResponse' && promptQuestionId && { answersPrompt: promptQuestionId }),
+      });
 
-    await SendData('messages', {
-      body: finalMessage,
-      bodyType: 'text',
-      conversation: router.query.conversationId,
-      channels,
-      ...(parentMessageId !== undefined && { parentMessage: parentMessageId }),
-      ...(messageSource === 'promptResponse' && promptQuestionId && { answersPrompt: promptQuestionId }),
-    });
+      if (response.error) return false;
 
-    // Auto-exit controlled mode after sending
-    if (controlledMode) {
-      setControlledMode(null);
+      // Auto-exit controlled mode after sending
+      if (controlledMode) {
+        setControlledMode(null);
+      }
+
+      return true;
+    } catch (error) {
+      console.error('Error sending message:', error);
+      return false;
     }
   }
 
@@ -812,10 +820,11 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
                           botName={botName}
                           inputValue={chatInputValue}
                           onInputChange={setChatInputValue}
-                          onSendMessage={(msg, parentMessageId) => {
+                          onSendMessage={async (msg, parentMessageId) => {
                             // Wait for response if message mentions the bot
                             const mentionsBot = msg.includes(`@${botName}`);
-                            sendMessage(msg, mentionsBot, parentMessageId);
+                            const success = await sendMessage(msg, mentionsBot, parentMessageId);
+                            return success;
                           }}
                           controlledMode={controlledMode}
                           onExitControlledMode={exitControlledMode}
@@ -854,7 +863,10 @@ function EventAssistantRoom({ authType: _authType }: { authType: AuthType }) {
                           botName={botName}
                           inputValue={assistantInputValue}
                           onInputChange={setAssistantInputValue}
-                          onSendMessage={(msg, parentMessageId) => sendMessage(msg, true, parentMessageId)}
+                          onSendMessage={async (msg, parentMessageId) => {
+                            const success = await sendMessage(msg, true, parentMessageId);
+                            return success;
+                          }}
                           onExitControlledMode={exitControlledMode}
                           onPromptSelect={handlePromptSelect}
                           userId={userId}


### PR DESCRIPTION
## What is in this PR?
This updates the message sending flow to allow the UI to respond appropriately when a message fails to send. As of now per [#223](https://github.com/berkmancenter/nextspace_archive/issues/223), the input field is cleared even when a message is not sent; for example, when a passcode is incorrect. 

## Changes in the codebase
- `onSendMessage` callback now returns a `Promise<boolean>` indicating success, which is used to determine whether to clear the input field. 
- Updates to the message input components, props.
- Message sending logic in the assistant page now returns a boolean and handles errors more robustly.
- Updated the `handleSend` function in `MessageInput` to clear the input only if `onSendMessage` resolves to `true`.
- Modified the message sending logic in `pages/assistant.tsx` to return `false` on failure and `true` on success, with error handling for failed sends.
- Updated all usages of `onSendMessage` in `pages/assistant.tsx` to handle the new async boolean return value.
- Updated tests in `MessageInput.Test.tsx`.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

<!-- Give your reviewer some context and specific recommendations with easy to follow steps how to test your work. -->

- [ ] Before applying this change, note that sending a message from either the group chat or the DM clears the input field, even if the message send fails. (Try artificially blocking network requests or appearing offline, or using an invalid passcode).
- [ ] After applying this change, note that when a message does not successfully send, the input is not cleared.

## Additional information

<!-- Provide any additional information that might be useful to the reviewer in evaluating this pull request. This could include performance considerations,design choices, etc. -->
Incorrect passcode errors will be silent until #117 is merged.