### PR TITLE
Adds the ability to edit events after creation

### DIFF
--- a/__tests__/components/Event/Status.test.tsx
+++ b/__tests__/components/Event/Status.test.tsx
@@ -13,6 +13,20 @@ jest.mock('../../../utils', () => ({
   SendData: jest.fn(),
 }));
 
+const mockPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('../../../utils/SessionManager', () => ({
+  __esModule: true,
+  default: {
+    get: () => ({
+      getSessionInfo: () => ({ userId: 'current-user-id' }),
+    }),
+  },
+}));
+
 // Mock window.location
 const mockLocation = {
   protocol: 'http:',
@@ -106,6 +120,7 @@ describe('EventStatus', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPush.mockReset();
     (SendData as jest.Mock).mockResolvedValue({ success: true });
     (RetrieveData as jest.Mock).mockResolvedValue(mockConfig);
   });
@@ -194,6 +209,32 @@ describe('EventStatus', () => {
   it('displays active status if conversationData.active is true initially', () => {
     render(<EventStatus conversationData={{ ...mockConversationData, active: true }} />);
     expect(screen.getByText('The event is currently active.')).toBeInTheDocument();
+  });
+
+  describe('Edit Event button', () => {
+    it('shows Edit Event button for an inactive event owned by the current user', () => {
+      render(<EventStatus conversationData={{ ...mockConversationData, owner: 'current-user-id' }} />);
+      expect(screen.getByRole('button', { name: /edit event/i })).toBeInTheDocument();
+    });
+
+    it('does not show Edit Event button when the current user is not the owner', () => {
+      render(<EventStatus conversationData={{ ...mockConversationData, owner: 'other-user-id' }} />);
+      expect(screen.queryByRole('button', { name: /edit event/i })).not.toBeInTheDocument();
+    });
+
+    it('does not show Edit Event button when the event is active', () => {
+      render(<EventStatus conversationData={{ ...mockConversationData, owner: 'current-user-id', active: true }} />);
+      expect(screen.queryByRole('button', { name: /edit event/i })).not.toBeInTheDocument();
+    });
+
+    it('navigates to the edit page when Edit Event button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<EventStatus conversationData={{ ...mockConversationData, owner: 'current-user-id' }} />);
+
+      await user.click(screen.getByRole('button', { name: /edit event/i }));
+
+      expect(mockPush).toHaveBeenCalledWith('/admin/eventAssistant/edit/conv-123');
+    });
   });
 
   it('renders zoom link when provided in eventUrls', () => {

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -2726,6 +2726,128 @@ describe('EventCreationForm Component', () => {
       });
     });
 
+    describe('Cancel button', () => {
+      const renderEditForm = async (event: any = mockInitialEvent) => {
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={event} />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+      };
+
+      it('shows a Cancel button in edit mode', async () => {
+        await renderEditForm();
+        expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+      });
+
+      it('does not show a Cancel button in create mode', async () => {
+        await act(async () => {
+          render(<EventCreationForm />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+        expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+      });
+
+      it('navigates to the view page immediately when cancelled with no changes', async () => {
+        const user = userEvent.setup();
+        await renderEditForm();
+
+        await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+        await waitFor(() => {
+          expect(mockPush).toHaveBeenCalledWith('/admin/backChannel/view/conv-edit-123');
+        });
+      });
+
+      it('navigates immediately when a change is reverted back to the original value', async () => {
+        const user = userEvent.setup();
+        await renderEditForm();
+
+        const nameInput = screen.getByLabelText(/Event Name/i);
+        await user.clear(nameInput);
+        await user.type(nameInput, 'Temporary Edit');
+        await user.clear(nameInput);
+        await user.type(nameInput, 'My Existing Event');
+
+        await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+        await waitFor(() => {
+          expect(mockPush).toHaveBeenCalledWith('/admin/backChannel/view/conv-edit-123');
+        });
+      });
+
+      it('navigates immediately when the API returned a non-UTC ISO date and nothing was edited', async () => {
+        // The backend may return scheduledTime in a timezone-offset ISO format (e.g. "+00:00"),
+        // while DateTimePicker's onChange canonicalizes via dayjs().toISOString() ("Z"). Without
+        // normalization in the snapshot, an untouched form would compare unequal and trigger the
+        // unsaved-changes dialog on Cancel. This guards that normalization stays in place.
+        const eventWithOffsetDate = {
+          ...mockInitialEvent,
+          scheduledTime: '2030-01-15T15:00:00+00:00',
+          scheduledEndTime: '2030-01-15T16:00:00+00:00',
+        };
+        const user = userEvent.setup();
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={eventWithOffsetDate} />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+
+        await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+        await waitFor(() => {
+          expect(mockPush).toHaveBeenCalledWith('/admin/backChannel/view/conv-edit-123');
+        });
+      });
+
+      it('shows a confirmation dialog when cancelled after making a change', async () => {
+        const user = userEvent.setup();
+        await renderEditForm();
+
+        const nameInput = screen.getByLabelText(/Event Name/i);
+        await user.clear(nameInput);
+        await user.type(nameInput, 'Changed Name');
+
+        await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText(/discard changes/i)).toBeInTheDocument();
+      });
+
+      it('navigates away when the user confirms discarding changes', async () => {
+        const user = userEvent.setup();
+        await renderEditForm();
+
+        const nameInput = screen.getByLabelText(/Event Name/i);
+        await user.clear(nameInput);
+        await user.type(nameInput, 'Changed Name');
+
+        await user.click(screen.getByRole('button', { name: /cancel/i }));
+        await screen.findByRole('dialog');
+        await user.click(screen.getByRole('button', { name: /discard/i }));
+
+        await waitFor(() => {
+          expect(mockPush).toHaveBeenCalledWith('/admin/backChannel/view/conv-edit-123');
+        });
+      });
+
+      it('keeps the user on the form when they dismiss the confirmation dialog', async () => {
+        const user = userEvent.setup();
+        await renderEditForm();
+
+        const nameInput = screen.getByLabelText(/Event Name/i);
+        await user.clear(nameInput);
+        await user.type(nameInput, 'Changed Name');
+
+        await user.click(screen.getByRole('button', { name: /cancel/i }));
+        await screen.findByRole('dialog');
+        await user.click(screen.getByRole('button', { name: /keep editing/i }));
+
+        // The user stays on the form — no navigation occurred and the form is still interactive
+        expect(mockPush).not.toHaveBeenCalled();
+        expect(screen.getByLabelText(/Event Name/i)).toBeInTheDocument();
+      });
+
+    });
+
     describe('Step payload verification', () => {
       // Navigate to a specific step starting from the rendered edit form.
       const renderAndGoToStep = async (

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -2392,6 +2392,36 @@ describe('EventCreationForm Component', () => {
       });
     });
 
+    it('navigates to the view page after saving a legacy event with no type object set', async () => {
+      /* Legacy events may have conversationType (a string) but no type object. The
+         post-save redirect must not crash by reading type.name directly — it should
+         fall back to conversationType the same way the Cancel button does. */
+      const legacyEvent = {
+        ...mockInitialEvent,
+        type: undefined,
+        conversationType: 'backChannel',
+      };
+      (updateConversation as jest.Mock).mockResolvedValue({ id: 'conv-edit-123' });
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={legacyEvent} />);
+      });
+      await waitFor(() => screen.getByLabelText(/Event Name/i));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Nextspace'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Customize your conversation settings'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/admin/backChannel/view/conv-edit-123');
+      });
+    });
+
     describe('Agent type change hint', () => {
       const navigateToStep2 = async (user: ReturnType<typeof userEvent.setup>) => {
         await waitFor(() => screen.getByLabelText(/Event Name/i));
@@ -2670,7 +2700,7 @@ describe('EventCreationForm Component', () => {
             properties: [],
             platforms: [],
           },
-          features: [], // collectiveVoice was explicitly disabled — not present in array
+          features: [], // collectiveVoice was explicitly disabled, so it's absent from the array
         };
 
         const user = userEvent.setup();
@@ -2776,10 +2806,10 @@ describe('EventCreationForm Component', () => {
       });
 
       it('navigates immediately when the API returned a non-UTC ISO date and nothing was edited', async () => {
-        // The backend may return scheduledTime in a timezone-offset ISO format (e.g. "+00:00"),
-        // while DateTimePicker's onChange canonicalizes via dayjs().toISOString() ("Z"). Without
-        // normalization in the snapshot, an untouched form would compare unequal and trigger the
-        // unsaved-changes dialog on Cancel. This guards that normalization stays in place.
+        /* The API may return dates with a timezone offset rather than UTC "Z".
+           Without normalizing both sides to the same format, an untouched form
+           compares unequal and shows the unsaved-changes warning on Cancel. This
+           test guards that the normalization stays in place. */
         const eventWithOffsetDate = {
           ...mockInitialEvent,
           scheduledTime: '2030-01-15T15:00:00+00:00',
@@ -2846,6 +2876,27 @@ describe('EventCreationForm Component', () => {
         expect(screen.getByLabelText(/Event Name/i)).toBeInTheDocument();
       });
 
+    });
+
+    it('allows proceeding from Step 1 when the pre-filled scheduled time is in the past', async () => {
+      /* In edit mode the start-time picker must not enforce a future-only constraint.
+         An existing event's scheduled time may be in the past, and blocking navigation
+         would prevent the organizer from editing any other field. */
+      const pastEvent = {
+        ...mockInitialEvent,
+        scheduledTime: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      };
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={pastEvent} />);
+      });
+      await waitFor(() => screen.getByLabelText(/Event Name/i));
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Nextspace')).toBeInTheDocument();
+      });
     });
 
     describe('Step payload verification', () => {

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -272,7 +272,15 @@ const mockConfig = {
           description: 'Contributes to the group chat by surfacing what participants are privately thinking.',
           userControlled: false,
           default: true,
-          properties: [],
+          properties: [
+            {
+              name: 'minContributionInterval',
+              label: 'Minimum Minutes Between Contributions',
+              type: 'number',
+              default: 10,
+              required: false,
+            },
+          ],
         },
         {
           name: 'catalyst',
@@ -280,7 +288,15 @@ const mockConfig = {
           description: 'Participates in the group chat as an active voice, jumping into silences.',
           userControlled: false,
           default: true,
-          properties: [],
+          properties: [
+            {
+              name: 'minContributionInterval',
+              label: 'Minimum Minutes Between Contributions',
+              type: 'number',
+              default: 10,
+              required: false,
+            },
+          ],
         },
         {
           name: 'librarian',
@@ -288,7 +304,15 @@ const mockConfig = {
           description: 'Periodically recommends relevant reading during the event.',
           userControlled: false,
           default: true,
-          properties: [],
+          properties: [
+            {
+              name: 'recommendationsPerInterval',
+              label: 'Number of Reading Recommendations per Interval',
+              type: 'number',
+              default: 2,
+              required: false,
+            },
+          ],
         },
         {
           name: 'mod',
@@ -2686,11 +2710,12 @@ describe('EventCreationForm Component', () => {
         });
       });
 
-      it('shows a default:true feature as unchecked when it was disabled in the saved event', async () => {
-        // eventAssistantExtraTest has collectiveVoice with default: true.
-        // If the user previously disabled it, the saved features array won't contain it.
-        // The form must not re-enable it just because the type definition defaults to true.
-        const eventWithFeatureDisabled: any = {
+      it('falls back to the type default for features absent from the saved features array', async () => {
+        /* Matches the backend's getFeatures() contract: a feature missing from the
+           stored array uses the type's default. This is the legacy event case (features
+           were dropped by the pre-markModified persistence bug), and also covers events
+           created before a feature existed on the type. */
+        const legacyEvent: any = {
           ...mockInitialEvent,
           platforms: ['zoom'],
           conversationType: 'eventAssistantExtraTest',
@@ -2700,14 +2725,37 @@ describe('EventCreationForm Component', () => {
             properties: [],
             platforms: [],
           },
-          features: [], // collectiveVoice was explicitly disabled, so it's absent from the array
+          features: [], // no features persisted, so the form falls back to type defaults
         };
 
         const user = userEvent.setup();
-        await renderAndGoToStep3(user, eventWithFeatureDisabled);
+        await renderAndGoToStep3(user, legacyEvent);
 
-        const collectiveVoiceCheckbox = screen.getByRole('checkbox', { name: /collective voice/i });
-        expect(collectiveVoiceCheckbox).not.toBeChecked();
+        // collectiveVoice and librarian both have default: true on the type
+        expect(screen.getByRole('checkbox', { name: /collective voice/i })).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: /reading recommendations/i })).toBeChecked();
+      });
+
+      it('respects an explicit disabled record in the saved features array', async () => {
+        /* The default fallback only applies when a feature is absent from the array.
+           An explicit enabled: false record should still win over the type's default. */
+        const eventWithExplicitDisable: any = {
+          ...mockInitialEvent,
+          platforms: ['zoom'],
+          conversationType: 'eventAssistantExtraTest',
+          type: {
+            name: 'eventAssistantExtraTest',
+            label: 'Event Assistant With Additional Features',
+            properties: [],
+            platforms: [],
+          },
+          features: [{ name: 'collectiveVoice', enabled: false, config: {} }],
+        };
+
+        const user = userEvent.setup();
+        await renderAndGoToStep3(user, eventWithExplicitDisable);
+
+        expect(screen.getByRole('checkbox', { name: /collective voice/i })).not.toBeChecked();
       });
 
       it('includes a newly enabled feature in the payload alongside pre-existing ones', async () => {
@@ -2727,6 +2775,105 @@ describe('EventCreationForm Component', () => {
                 { name: 'liveTranscript', config: { transcriptDelay: 10 } },
                 { name: 'autoSummary', config: {} },
               ]),
+            }),
+          );
+        });
+      });
+    });
+
+    describe('Catalyst timing in edit mode', () => {
+      /* Catalyst's minContributionInterval is fixed once the event is created. In edit
+         mode the organizer can only toggle the feature on or off. The input is hidden,
+         and the saved value goes back in the update payload unchanged. */
+      const mockCatalystEvent: any = {
+        ...mockInitialEvent,
+        platforms: ['zoom'],
+        conversationType: 'eventAssistantExtraTest',
+        type: {
+          name: 'eventAssistantExtraTest',
+          label: 'Event Assistant With Additional Features',
+          properties: [],
+          platforms: [],
+        },
+        /* Explicitly disable Collective Voice and Librarian. They share the same
+           "Minimum Minutes Between Contributions" label as catalyst, so leaving them
+           at their default of true would cause the hide-input assertion below to find
+           the wrong field. */
+        features: [
+          { name: 'catalyst', enabled: true, config: { minContributionInterval: 7 } },
+          { name: 'collectiveVoice', enabled: false, config: {} },
+          { name: 'librarian', enabled: false, config: {} },
+        ],
+      };
+
+      const goToStep3 = async (user: ReturnType<typeof userEvent.setup>, event: any) => {
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={event} />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Nextspace'));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Customize your conversation settings'));
+      };
+
+      it('still shows Collective Voice and Reading Recommendations sub-fields in edit mode', async () => {
+        // Regression: the catalyst-only hide rule should not affect peer features that
+        // share the same minContributionInterval shape. Collective Voice and Librarian's
+        // sub-properties stay editable in edit mode.
+        const eventWithAllThree: any = {
+          ...mockInitialEvent,
+          platforms: ['zoom'],
+          conversationType: 'eventAssistantExtraTest',
+          type: {
+            name: 'eventAssistantExtraTest',
+            label: 'Event Assistant With Additional Features',
+            properties: [],
+            platforms: [],
+          },
+          features: [
+            { name: 'collectiveVoice', enabled: true, config: { minContributionInterval: 5 } },
+            { name: 'librarian', enabled: true, config: { recommendationsPerInterval: 3 } },
+          ],
+        };
+
+        const user = userEvent.setup();
+        await goToStep3(user, eventWithAllThree);
+
+        // Collective Voice's sub-property must render with the saved value
+        const cvInputs = screen.getAllByLabelText(/Minimum Minutes Between Contributions/i) as HTMLInputElement[];
+        expect(cvInputs.length).toBeGreaterThanOrEqual(1);
+        expect(cvInputs.some((i) => i.value === '5')).toBe(true);
+
+        // Librarian's sub-property must render with the saved value
+        const libInput = screen.getByLabelText(/Number of Reading Recommendations per Interval/i) as HTMLInputElement;
+        expect(libInput.value).toBe('3');
+      });
+
+      it('hides the catalyst timing input in edit mode even when the feature is enabled', async () => {
+        const user = userEvent.setup();
+        await goToStep3(user, mockCatalystEvent);
+
+        // Catalyst is checked, but its sub-property input must not render in edit mode
+        expect(screen.getByRole('checkbox', { name: /catalyst/i })).toBeChecked();
+        expect(screen.queryByLabelText(/Minimum Minutes Between Contributions/i)).not.toBeInTheDocument();
+      });
+
+      it('preserves the saved catalyst timing in the payload when re-saved unchanged', async () => {
+        const user = userEvent.setup();
+        await goToStep3(user, mockCatalystEvent);
+
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('About the Speakers'));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Reading & Resources'));
+        await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => {
+          expect(updateConversation).toHaveBeenCalledWith(
+            'conv-edit-123',
+            expect.objectContaining({
+              features: expect.arrayContaining([{ name: 'catalyst', config: { minContributionInterval: 7 } }]),
             }),
           );
         });
@@ -3033,6 +3180,30 @@ describe('EventCreationForm Component', () => {
               }),
             );
           });
+        });
+
+        it('allows advancing past Step 1 when a saved event has a start time but no end time', async () => {
+          /* Regression: in create mode, an end time is required once a start time is set.
+             That rule blocked editing legacy events with no persisted end time. The
+             backend treats scheduledEndTime as optional, so the frontend shouldn't gate
+             edits on it. */
+          const legacyEventNoEndTime: any = {
+            ...mockInitialEvent,
+            scheduledTime: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+            scheduledEndTime: undefined,
+          };
+
+          const user = userEvent.setup();
+          await act(async () => {
+            render(<EventCreationForm mode="edit" initialEvent={legacyEventNoEndTime} />);
+          });
+          await waitFor(() => screen.getByLabelText(/Event Name/i));
+
+          await user.click(screen.getByRole('button', { name: /next/i }));
+
+          // Reached Step 2 (Conversation Setup) without the end-time-required error
+          await waitFor(() => screen.getByText('Nextspace'));
+          expect(screen.queryByText(/Meeting End Time is required when a start time is provided/i)).not.toBeInTheDocument();
         });
 
         it('includes the updated topic ID in the payload', async () => {

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -427,6 +427,25 @@ describe('EventCreationForm Component', () => {
     expect(screen.getByLabelText(/Zoom Meeting URL/i)).toBeInTheDocument();
   });
 
+  it('prevents native form submission to avoid full page reloads on Enter keypress', async () => {
+    await act(async () => {
+      render(<EventCreationForm />);
+    });
+
+    const form = document.querySelector('form');
+    expect(form).toBeInTheDocument();
+
+    /* Pressing Enter inside a text field fires a native submit event. Without
+       onSubmit={e => e.preventDefault()}, the form submits to action="#", which
+       triggers a full browser reload in Next.js — bypassing the router entirely. */
+    const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+    act(() => {
+      form!.dispatchEvent(submitEvent);
+    });
+
+    expect(submitEvent.defaultPrevented).toBe(true);
+  });
+
   it('validates Step 1 before allowing navigation to Step 2', async () => {
     const user = userEvent.setup();
     await act(async () => {
@@ -1335,7 +1354,7 @@ describe('EventCreationForm Component', () => {
       expect(screen.queryByLabelText(/Transcript Delay/i)).not.toBeInTheDocument();
     });
 
-    it('includes features as an empty array in the payload when none are enabled', async () => {
+    it('includes all features with enabled: false in the payload when none are enabled', async () => {
       const user = userEvent.setup();
       (Request as jest.Mock).mockImplementation(
         makeRequestMock({
@@ -1361,7 +1380,10 @@ describe('EventCreationForm Component', () => {
 
       await waitFor(() => {
         const conversationCall = (Request as jest.Mock).mock.calls.find((call) => call[0] === 'conversations/from-type');
-        expect(conversationCall![1]).toHaveProperty('features', []);
+        expect(conversationCall![1]).toHaveProperty('features', [
+          { name: 'liveTranscript', enabled: false, config: {} },
+          { name: 'autoSummary', enabled: false, config: {} },
+        ]);
       });
     });
 
@@ -1401,8 +1423,8 @@ describe('EventCreationForm Component', () => {
           'conversations/from-type',
           expect.objectContaining({
             features: expect.arrayContaining([
-              { name: 'liveTranscript', config: { transcriptDelay: 5 } },
-              { name: 'autoSummary', config: {} },
+              { name: 'liveTranscript', enabled: true, config: { transcriptDelay: 5 } },
+              { name: 'autoSummary', enabled: true, config: {} },
             ]),
           }),
         );
@@ -1458,6 +1480,34 @@ describe('EventCreationForm Component', () => {
       await waitFor(() => screen.getByLabelText(/Bot Name/i));
 
       expect(screen.queryByText('Features')).not.toBeInTheDocument();
+    });
+
+    it('blurs number inputs on scroll wheel to prevent accidental value changes', async () => {
+      /* MUI type="number" TextFields fire onChange when the scroll wheel moves while
+         the input has focus. If the input is not blurred on wheel events, scrolling the
+         page (or scrolling to find a value) silently mutates the field. The fix adds an
+         onWheel handler that calls blur(), which removes focus and stops the browser from
+         intercepting the scroll. This test confirms that behavior. */
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm />);
+      });
+
+      await navigateToStep3WithBackChannel(user);
+
+      // Enable the liveTranscript feature so its number sub-property (transcriptDelay) is visible
+      await user.click(screen.getByRole('checkbox', { name: /live transcript/i }));
+      const numberInput = await screen.findByLabelText(/Transcript Delay/i);
+
+      // Focus the input, confirm it has focus, then fire a scroll-wheel event
+      numberInput.focus();
+      expect(numberInput).toHaveFocus();
+
+      fireEvent.wheel(numberInput, { deltaY: -100 });
+
+      // After the onWheel handler calls blur(), the input should no longer have focus.
+      // Before the fix, there is no handler and the input stays focused.
+      expect(numberInput).not.toHaveFocus();
     });
   });
 
@@ -2583,7 +2633,7 @@ describe('EventCreationForm Component', () => {
       });
     });
 
-    it('always includes features in the payload even when none are enabled', async () => {
+    it('includes all features with enabled: false in the payload when none are enabled', async () => {
       const user = userEvent.setup();
       await act(async () => {
         render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
@@ -2603,7 +2653,15 @@ describe('EventCreationForm Component', () => {
       await user.click(screen.getByRole('button', { name: /save changes/i }));
 
       await waitFor(() => {
-        expect(updateConversation).toHaveBeenCalledWith('conv-edit-123', expect.objectContaining({ features: [] }));
+        expect(updateConversation).toHaveBeenCalledWith(
+          'conv-edit-123',
+          expect.objectContaining({
+            features: [
+              { name: 'liveTranscript', enabled: false, config: {} },
+              { name: 'autoSummary', enabled: false, config: {} },
+            ],
+          }),
+        );
       });
     });
 
@@ -2652,17 +2710,17 @@ describe('EventCreationForm Component', () => {
           expect(updateConversation).toHaveBeenCalledWith(
             'conv-edit-123',
             expect.objectContaining({
-              features: expect.arrayContaining([{ name: 'liveTranscript', config: { transcriptDelay: 10 } }]),
+              features: expect.arrayContaining([{ name: 'liveTranscript', enabled: true, config: { transcriptDelay: 10 } }]),
             }),
           );
         });
       });
 
-      it('removes only the disabled feature from the payload, preserving others', async () => {
+      it('sets enabled: false on unchecked feature while preserving enabled: true on others', async () => {
         const user = userEvent.setup();
         await renderAndGoToStep3(user, mockEventWithBothFeatures);
 
-        // Uncheck liveTranscript — autoSummary should remain
+        // Uncheck liveTranscript — it should appear in payload with enabled: false
         await user.click(screen.getByRole('checkbox', { name: /live transcript/i }));
 
         await submitFromStep3(user);
@@ -2670,13 +2728,14 @@ describe('EventCreationForm Component', () => {
         await waitFor(() => {
           const call = (updateConversation as jest.Mock).mock.calls[0];
           const payload = call[1];
-          const featureNames = payload.features.map((f: any) => f.name);
-          expect(featureNames).not.toContain('liveTranscript');
-          expect(featureNames).toContain('autoSummary');
+          const liveTranscript = payload.features.find((f: any) => f.name === 'liveTranscript');
+          const autoSummary = payload.features.find((f: any) => f.name === 'autoSummary');
+          expect(liveTranscript).toMatchObject({ name: 'liveTranscript', enabled: false });
+          expect(autoSummary).toMatchObject({ name: 'autoSummary', enabled: true });
         });
       });
 
-      it('sends features: [] when all pre-enabled features are disabled', async () => {
+      it('sets enabled: false on all features when all are unchecked', async () => {
         const user = userEvent.setup();
         await renderAndGoToStep3(user, mockEventWithBothFeatures);
 
@@ -2686,7 +2745,15 @@ describe('EventCreationForm Component', () => {
         await submitFromStep3(user);
 
         await waitFor(() => {
-          expect(updateConversation).toHaveBeenCalledWith('conv-edit-123', expect.objectContaining({ features: [] }));
+          expect(updateConversation).toHaveBeenCalledWith(
+            'conv-edit-123',
+            expect.objectContaining({
+              features: [
+                { name: 'liveTranscript', enabled: false, config: {} },
+                { name: 'autoSummary', enabled: false, config: {} },
+              ],
+            }),
+          );
         });
       });
 
@@ -2704,7 +2771,7 @@ describe('EventCreationForm Component', () => {
           expect(updateConversation).toHaveBeenCalledWith(
             'conv-edit-123',
             expect.objectContaining({
-              features: expect.arrayContaining([{ name: 'liveTranscript', config: { transcriptDelay: 20 } }]),
+              features: expect.arrayContaining([{ name: 'liveTranscript', enabled: true, config: { transcriptDelay: 20 } }]),
             }),
           );
         });
@@ -2758,6 +2825,47 @@ describe('EventCreationForm Component', () => {
         expect(screen.getByRole('checkbox', { name: /collective voice/i })).not.toBeChecked();
       });
 
+      it('includes a disabled user-controlled feature (mindmap) in the payload with enabled: false', async () => {
+        /* mindmap is userControlled: true — it is not shown in the admin form,
+           so the admin cannot toggle it. But if the server has it saved as
+           enabled: false, that state must still reach updateConversation so the
+           server can persist the explicit disable rather than falling back to the
+           type default (true). */
+        const eventWithDisabledMindmap: any = {
+          ...mockInitialEvent,
+          platforms: ['zoom'],
+          conversationType: 'eventAssistantExtraTest',
+          type: {
+            name: 'eventAssistantExtraTest',
+            label: 'Event Assistant With Additional Features',
+            properties: [],
+            platforms: [],
+          },
+          features: [{ name: 'mindmap', enabled: false, config: {} }],
+        };
+
+        const user = userEvent.setup();
+        await renderAndGoToStep3(user, eventWithDisabledMindmap);
+        await submitFromStep3(user);
+
+        await waitFor(() => {
+          expect(updateConversation).toHaveBeenCalledWith(
+            'conv-edit-123',
+            expect.objectContaining({
+              features: [
+                { name: 'collectiveVoice', enabled: true, config: { minContributionInterval: 10 } },
+                { name: 'catalyst', enabled: true, config: { minContributionInterval: 10 } },
+                { name: 'librarian', enabled: true, config: { recommendationsPerInterval: 2 } },
+                { name: 'mod', enabled: true, config: {} },
+                { name: 'mindmap', enabled: false, config: {} },
+                { name: 'visual', enabled: true, config: {} },
+                { name: 'jargonFilter', enabled: true, config: {} },
+              ],
+            }),
+          );
+        });
+      });
+
       it('includes a newly enabled feature in the payload alongside pre-existing ones', async () => {
         const user = userEvent.setup();
         // Start with only liveTranscript; enable autoSummary during edit
@@ -2772,8 +2880,8 @@ describe('EventCreationForm Component', () => {
             'conv-edit-123',
             expect.objectContaining({
               features: expect.arrayContaining([
-                { name: 'liveTranscript', config: { transcriptDelay: 10 } },
-                { name: 'autoSummary', config: {} },
+                { name: 'liveTranscript', enabled: true, config: { transcriptDelay: 10 } },
+                { name: 'autoSummary', enabled: true, config: {} },
               ]),
             }),
           );
@@ -2873,7 +2981,7 @@ describe('EventCreationForm Component', () => {
           expect(updateConversation).toHaveBeenCalledWith(
             'conv-edit-123',
             expect.objectContaining({
-              features: expect.arrayContaining([{ name: 'catalyst', config: { minContributionInterval: 7 } }]),
+              features: expect.arrayContaining([{ name: 'catalyst', enabled: true, config: { minContributionInterval: 7 } }]),
             }),
           );
         });
@@ -3022,7 +3130,6 @@ describe('EventCreationForm Component', () => {
         expect(mockPush).not.toHaveBeenCalled();
         expect(screen.getByLabelText(/Event Name/i)).toBeInTheDocument();
       });
-
     });
 
     it('allows proceeding from Step 1 when the pre-filled scheduled time is in the past', async () => {
@@ -3043,6 +3150,95 @@ describe('EventCreationForm Component', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Nextspace')).toBeInTheDocument();
+      });
+    });
+
+    describe('Save overlay', () => {
+      /* Renders the form in edit mode and clicks through to the given step.
+         Defined here so overlay tests can reuse it without depending on the
+         Step payload verification describe block's inner scope. */
+      const goToStep = async (user: ReturnType<typeof userEvent.setup>, step: number, event: any = mockInitialEvent) => {
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={event} />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+        for (let i = 1; i < step; i++) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+        }
+        if (step >= 5) await waitFor(() => screen.getByText('Reading & Resources'));
+      };
+
+      it('shows a "Saving changes..." overlay while the update request is in flight', async () => {
+        const user = userEvent.setup();
+
+        let resolveUpdate: (value: any) => void;
+        (updateConversation as jest.Mock).mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolveUpdate = resolve;
+            }),
+        );
+
+        await goToStep(user, 5);
+        await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+        expect(screen.getByText('Saving changes...')).toBeInTheDocument();
+
+        // Resolve to avoid a dangling promise after the test exits
+        await act(async () => {
+          resolveUpdate({ id: 'conv-edit-123', resources: [] });
+        });
+      });
+
+      it('updates the overlay to "Uploading PDF..." after saving when a PDF is attached', async () => {
+        const user = userEvent.setup();
+
+        (updateConversation as jest.Mock).mockResolvedValue({
+          id: 'conv-edit-123',
+          resources: [{ id: 'res-1', title: 'Test Paper' }],
+        });
+
+        let resolveUpload: (value: any) => void;
+        (SendData as jest.Mock).mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolveUpload = resolve;
+            }),
+        );
+
+        await goToStep(user, 5);
+
+        await user.type(screen.getByLabelText(/^Title/i), 'Test Paper');
+        const input = document.getElementById('pdf-upload-0') as HTMLInputElement;
+        await user.upload(input, new File(['content'], 'test.pdf', { type: 'application/pdf' }));
+        await waitFor(() => screen.getByText('test.pdf'));
+
+        await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => {
+          expect(screen.getByText('Uploading PDF...')).toBeInTheDocument();
+        });
+
+        await act(async () => {
+          resolveUpload({});
+        });
+      });
+
+      it('hides the overlay and shows an error if the update request fails', async () => {
+        const user = userEvent.setup();
+
+        (updateConversation as jest.Mock).mockResolvedValue({
+          error: true,
+          message: { message: 'Server error' },
+        });
+
+        await goToStep(user, 5);
+        await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => {
+          expect(screen.queryByText('Saving changes...')).not.toBeInTheDocument();
+          expect(screen.getByText(/Server error/i)).toBeInTheDocument();
+        });
       });
     });
 
@@ -3473,6 +3669,82 @@ describe('EventCreationForm Component', () => {
           await waitFor(() => {
             const call = (updateConversation as jest.Mock).mock.calls[0];
             expect(call[1].resources ?? []).toHaveLength(0);
+          });
+        });
+
+        it('uploads the PDF after saving changes in edit mode when a resource has one attached', async () => {
+          /* In create mode, the PDF upload runs after Request('conversations/from-type') returns.
+             In edit mode, the form calls updateConversation and returns early, so the upload
+             block is skipped. This test confirms the upload happens in edit mode too. */
+          const user = userEvent.setup();
+
+          // Return a resource with an ID so the upload endpoint can be built
+          (updateConversation as jest.Mock).mockResolvedValue({
+            id: 'conv-edit-123',
+            resources: [{ id: 'res-edit-abc', title: 'Edit Paper' }],
+          });
+          (SendData as jest.Mock).mockResolvedValue({});
+
+          await renderAndGoToStep(user, 5);
+
+          await user.type(screen.getByLabelText(/^Title/i), 'Edit Paper');
+
+          const validFile = new File(['content'], 'edit-paper.pdf', { type: 'application/pdf' });
+          const input = document.getElementById('pdf-upload-0') as HTMLInputElement;
+          await user.upload(input, validFile);
+          await waitFor(() => screen.getByText('edit-paper.pdf'));
+
+          await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+          await waitFor(() => {
+            expect(SendData).toHaveBeenCalledWith(
+              'resources/conv-edit-123/res-edit-abc/pdf',
+              null,
+              undefined,
+              expect.objectContaining({ method: 'POST', body: expect.any(FormData) }),
+            );
+          });
+        });
+
+        it('shows "PDF already uploaded" when a resource already has one saved on the server', async () => {
+          /*
+           * The API returns hasPdf: true (derived from fileName, which is private).
+           * The form should display an indicator rather than the empty drop zone so
+           * users know a PDF is attached, and re-saving without changes preserves it.
+           */
+          const user = userEvent.setup();
+          const eventWithPdf: any = {
+            ...mockInitialEvent,
+            resources: [{ id: 'res-abc', title: 'Existing Paper', hasPdf: true }],
+          };
+          await renderAndGoToStep(user, 5, eventWithPdf);
+
+          expect(screen.getByText('PDF already uploaded')).toBeInTheDocument();
+          expect(screen.queryByText(/drop a pdf/i)).not.toBeInTheDocument();
+        });
+
+        it('includes the resource id in the save payload so the server can preserve the existing PDF', async () => {
+          /*
+           * updateResources() on the server matches incoming resources to existing ones by id
+           * to carry over fileName. Without id in the payload, the server can't match, and
+           * fileName is lost on re-save even when the user made no changes.
+           */
+          const user = userEvent.setup();
+          const eventWithPdf: any = {
+            ...mockInitialEvent,
+            resources: [{ id: 'res-abc', title: 'Existing Paper', hasPdf: true }],
+          };
+          await renderAndGoToStep(user, 5, eventWithPdf);
+
+          await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                resources: expect.arrayContaining([expect.objectContaining({ id: 'res-abc', title: 'Existing Paper' })]),
+              }),
+            );
           });
         });
       });

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { EventCreationForm } from '../../components/EventCreationForm';
 import { RetrieveData, Request } from '../../utils';
-import { Api, SendData } from '../../utils/Helpers';
+import { Api, SendData, updateConversation } from '../../utils/Helpers';
 import '@testing-library/jest-dom';
 
 jest.setTimeout(60000);
@@ -43,6 +43,7 @@ jest.mock('../../utils', () => ({
 jest.mock('../../utils/Helpers', () => ({
   ...jest.requireActual('../../utils/Helpers'),
   SendData: jest.fn(),
+  updateConversation: jest.fn(),
 }));
 
 jest.mock('../../utils/SessionManager', () => ({
@@ -1310,7 +1311,7 @@ describe('EventCreationForm Component', () => {
       expect(screen.queryByLabelText(/Transcript Delay/i)).not.toBeInTheDocument();
     });
 
-    it('does not include features in submission payload when none are enabled', async () => {
+    it('includes features as an empty array in the payload when none are enabled', async () => {
       const user = userEvent.setup();
       (Request as jest.Mock).mockImplementation(
         makeRequestMock({
@@ -1336,7 +1337,7 @@ describe('EventCreationForm Component', () => {
 
       await waitFor(() => {
         const conversationCall = (Request as jest.Mock).mock.calls.find((call) => call[0] === 'conversations/from-type');
-        expect(conversationCall![1]).not.toHaveProperty('features');
+        expect(conversationCall![1]).toHaveProperty('features', []);
       });
     });
 
@@ -2262,6 +2263,875 @@ describe('EventCreationForm Component', () => {
 
       await waitFor(() => screen.getByText('Event Status'));
       expect(SendData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Edit mode', () => {
+    const mockInitialEvent: any = {
+      id: 'conv-edit-123',
+      name: 'My Existing Event',
+      description: 'An existing event description',
+      active: false,
+      owner: 'current-user-id',
+      properties: {
+        zoomMeetingUrl: 'https://zoom.us/j/existing',
+        botName: 'ExistingBot',
+      },
+      scheduledTime: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      scheduledEndTime: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      platforms: ['zoom'],
+      conversationType: 'backChannel',
+      type: {
+        name: 'backChannel',
+        label: 'Back Channel',
+        description: 'An agent to analyze participant comments',
+        properties: [],
+        platforms: [],
+      },
+      topic: 'topic-1',
+      moderators: [],
+      presenters: [],
+      features: [],
+      channels: [],
+      agents: [],
+      adapters: [],
+      messages: [],
+      followers: [],
+      enableDMs: [],
+      experiments: [],
+      eventUrls: { moderator: [], participant: [] },
+    };
+
+    beforeEach(() => {
+      (updateConversation as jest.Mock).mockResolvedValue({ id: 'conv-edit-123' });
+    });
+
+    it('shows "Edit Event" as the form title in edit mode', async () => {
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit Event')).toBeInTheDocument();
+      });
+    });
+
+    it('pre-fills the event name from the existing conversation', async () => {
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+      });
+
+      await waitFor(() => {
+        const nameInput = screen.getByLabelText(/Event Name/i) as HTMLInputElement;
+        expect(nameInput.value).toBe('My Existing Event');
+      });
+    });
+
+    it('pre-fills the Zoom URL from the existing conversation', async () => {
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+      });
+
+      await waitFor(() => {
+        const urlInput = screen.getByLabelText(/Zoom Meeting URL/i) as HTMLInputElement;
+        expect(urlInput.value).toBe('https://zoom.us/j/existing');
+      });
+    });
+
+    it('shows "Save Changes" as the submit button in edit mode', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+      });
+
+      // Navigate to last step
+      await waitFor(() => screen.getByLabelText(/Event Name/i));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Nextspace'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Customize your conversation settings'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
+
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /create conversation/i })).not.toBeInTheDocument();
+    });
+
+    it('calls updateConversation on submit in edit mode, not Request', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+      });
+
+      // Navigate to last step
+      await waitFor(() => screen.getByLabelText(/Event Name/i));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Nextspace'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Customize your conversation settings'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
+
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(updateConversation).toHaveBeenCalledWith(
+          'conv-edit-123',
+          expect.objectContaining({
+            name: 'My Existing Event',
+            properties: expect.objectContaining({
+              zoomMeetingUrl: 'https://zoom.us/j/existing',
+            }),
+          }),
+        );
+        expect(Request).not.toHaveBeenCalledWith('conversations/from-type', expect.anything());
+      });
+    });
+
+    describe('Agent type change hint', () => {
+      const navigateToStep2 = async (user: ReturnType<typeof userEvent.setup>) => {
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Nextspace'));
+      };
+
+      it('shows hint when the user changes the pre-filled agent type', async () => {
+        const user = userEvent.setup();
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+        });
+
+        await navigateToStep2(user);
+
+        // Back Channel is pre-filled; switching to Event Assistant should trigger the hint
+        await user.click(screen.getByRole('radio', { name: /event assistant$/i }));
+
+        expect(screen.getByText(/changing the agent type will also update the bot name/i)).toBeInTheDocument();
+      });
+
+      it('does not show hint when first arriving at Step 2 without changing the selection', async () => {
+        const user = userEvent.setup();
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+        });
+
+        await navigateToStep2(user);
+
+        expect(screen.queryByText(/changing the agent type will also update the bot name/i)).not.toBeInTheDocument();
+      });
+
+      it('preserves the saved AI model when the agent type is changed', async () => {
+        const eventWithHaikuModel: any = {
+          ...mockInitialEvent,
+          properties: {
+            ...mockInitialEvent.properties,
+            llmModel: { llmPlatform: 'bedrock', llmModel: 'anthropic.claude-3-5-haiku-20241022-v1:0' },
+          },
+        };
+        const user = userEvent.setup();
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={eventWithHaikuModel} />);
+        });
+
+        await navigateToStep2(user);
+        // Switch from Back Channel to Event Assistant — whose first/default option is gpt-4o-mini
+        await user.click(screen.getByRole('radio', { name: /event assistant$/i }));
+        // Navigate to Step 3 (Zoom is already pre-filled from the event, no need to re-check)
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Customize your conversation settings'));
+
+        // The saved haiku model should still be selected, not reset to gpt-4o-mini
+        const haikuRadio = screen.getByRole('radio', { name: /AWS Bedrock Claude 3\.5 Haiku/i });
+        expect(haikuRadio).toBeChecked();
+      });
+    });
+
+    describe('Configuration pre-fill (Step 3)', () => {
+      // Uses a richer event that includes a non-default model and an enabled feature
+      // with a non-default sub-property value. Tests fail if the form resets these
+      // to type defaults instead of restoring the saved settings.
+      const mockInitialEventWithConfig: any = {
+        ...mockInitialEvent,
+        properties: {
+          zoomMeetingUrl: 'https://zoom.us/j/existing',
+          botName: 'ExistingBot',
+          // Non-default model (default is gpt-4o-mini / openai)
+          llmModel: { llmPlatform: 'bedrock', llmModel: 'anthropic.claude-3-5-haiku-20241022-v1:0' },
+        },
+        features: [{ name: 'liveTranscript', enabled: true, config: { transcriptDelay: 10 } }],
+      };
+
+      const navigateToStep3 = async (user: ReturnType<typeof userEvent.setup>, event = mockInitialEventWithConfig) => {
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={event} />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Nextspace'));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Customize your conversation settings'));
+      };
+
+      it('pre-fills bot name in Step 3', async () => {
+        const user = userEvent.setup();
+        await navigateToStep3(user);
+        const botNameInput = screen.getByLabelText(/Bot Name/i) as HTMLInputElement;
+        expect(botNameInput.value).toBe('ExistingBot');
+      });
+
+      it('pre-selects the saved AI model radio button in Step 3', async () => {
+        const user = userEvent.setup();
+        await navigateToStep3(user);
+        const claudeHaikuRadio = screen.getByRole('radio', {
+          name: /AWS Bedrock Claude 3\.5 Haiku/i,
+        });
+        expect(claudeHaikuRadio).toBeChecked();
+      });
+
+      it('pre-checks enabled feature toggles in Step 3', async () => {
+        const user = userEvent.setup();
+        await navigateToStep3(user);
+        const liveTranscriptCheckbox = screen.getByRole('checkbox', {
+          name: /Live Transcript/i,
+        });
+        expect(liveTranscriptCheckbox).toBeChecked();
+      });
+
+      it('pre-fills feature sub-property values in Step 3', async () => {
+        const user = userEvent.setup();
+        await navigateToStep3(user);
+        // transcriptDelay is only visible when liveTranscript is enabled
+        const delayInput = screen.getByLabelText(/Transcript Delay/i) as HTMLInputElement;
+        expect(delayInput.value).toBe('10');
+      });
+
+      it('pre-selects the correct model even when property keys come back in unexpected order', async () => {
+        // MongoDB Mixed fields don't guarantee key order, so the stored object may have
+        // keys in a different order than the form built when it was saved. The radio
+        // comparison must be key-order-agnostic or it silently resets to the default.
+        const eventWithReversedKeys: any = {
+          ...mockInitialEventWithConfig,
+          properties: {
+            ...mockInitialEventWithConfig.properties,
+            llmModel: { llmModel: 'anthropic.claude-3-5-haiku-20241022-v1:0', llmPlatform: 'bedrock' },
+          },
+        };
+        const user = userEvent.setup();
+        await navigateToStep3(user, eventWithReversedKeys);
+        const claudeHaikuRadio = screen.getByRole('radio', {
+          name: /AWS Bedrock Claude 3\.5 Haiku/i,
+        });
+        expect(claudeHaikuRadio).toBeChecked();
+      });
+    });
+
+    it('always includes features in the payload even when none are enabled', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+      });
+
+      // Navigate through all steps without enabling any features
+      await waitFor(() => screen.getByLabelText(/Event Name/i));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Nextspace'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Customize your conversation settings'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
+
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(updateConversation).toHaveBeenCalledWith('conv-edit-123', expect.objectContaining({ features: [] }));
+      });
+    });
+
+    describe('Features editing — payload', () => {
+      // Event with one feature enabled (liveTranscript)
+      const mockEventWithOneFeature: any = {
+        ...mockInitialEvent,
+        features: [{ name: 'liveTranscript', enabled: true, config: { transcriptDelay: 10 } }],
+      };
+
+      // Event with both features enabled
+      const mockEventWithBothFeatures: any = {
+        ...mockInitialEvent,
+        features: [
+          { name: 'liveTranscript', enabled: true, config: { transcriptDelay: 10 } },
+          { name: 'autoSummary', enabled: true, config: {} },
+        ],
+      };
+
+      const renderAndGoToStep3 = async (user: ReturnType<typeof userEvent.setup>, event: any = mockEventWithOneFeature) => {
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={event} />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Nextspace'));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Customize your conversation settings'));
+      };
+
+      const submitFromStep3 = async (user: ReturnType<typeof userEvent.setup>) => {
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('About the Speakers'));
+        await user.click(screen.getByRole('button', { name: /next/i }));
+        await waitFor(() => screen.getByText('Reading & Resources'));
+        await user.click(screen.getByRole('button', { name: /save changes/i }));
+      };
+
+      it('preserves a pre-enabled feature in the payload when it is not changed', async () => {
+        const user = userEvent.setup();
+        await renderAndGoToStep3(user);
+
+        await submitFromStep3(user);
+
+        await waitFor(() => {
+          expect(updateConversation).toHaveBeenCalledWith(
+            'conv-edit-123',
+            expect.objectContaining({
+              features: expect.arrayContaining([{ name: 'liveTranscript', config: { transcriptDelay: 10 } }]),
+            }),
+          );
+        });
+      });
+
+      it('removes only the disabled feature from the payload, preserving others', async () => {
+        const user = userEvent.setup();
+        await renderAndGoToStep3(user, mockEventWithBothFeatures);
+
+        // Uncheck liveTranscript — autoSummary should remain
+        await user.click(screen.getByRole('checkbox', { name: /live transcript/i }));
+
+        await submitFromStep3(user);
+
+        await waitFor(() => {
+          const call = (updateConversation as jest.Mock).mock.calls[0];
+          const payload = call[1];
+          const featureNames = payload.features.map((f: any) => f.name);
+          expect(featureNames).not.toContain('liveTranscript');
+          expect(featureNames).toContain('autoSummary');
+        });
+      });
+
+      it('sends features: [] when all pre-enabled features are disabled', async () => {
+        const user = userEvent.setup();
+        await renderAndGoToStep3(user, mockEventWithBothFeatures);
+
+        await user.click(screen.getByRole('checkbox', { name: /live transcript/i }));
+        await user.click(screen.getByRole('checkbox', { name: /auto summary/i }));
+
+        await submitFromStep3(user);
+
+        await waitFor(() => {
+          expect(updateConversation).toHaveBeenCalledWith('conv-edit-123', expect.objectContaining({ features: [] }));
+        });
+      });
+
+      it('saves an updated sub-property value in the payload', async () => {
+        const user = userEvent.setup();
+        await renderAndGoToStep3(user);
+
+        const delayInput = screen.getByLabelText(/Transcript Delay/i) as HTMLInputElement;
+        await user.clear(delayInput);
+        await user.type(delayInput, '20');
+
+        await submitFromStep3(user);
+
+        await waitFor(() => {
+          expect(updateConversation).toHaveBeenCalledWith(
+            'conv-edit-123',
+            expect.objectContaining({
+              features: expect.arrayContaining([{ name: 'liveTranscript', config: { transcriptDelay: 20 } }]),
+            }),
+          );
+        });
+      });
+
+      it('shows a default:true feature as unchecked when it was disabled in the saved event', async () => {
+        // eventAssistantExtraTest has collectiveVoice with default: true.
+        // If the user previously disabled it, the saved features array won't contain it.
+        // The form must not re-enable it just because the type definition defaults to true.
+        const eventWithFeatureDisabled: any = {
+          ...mockInitialEvent,
+          platforms: ['zoom'],
+          conversationType: 'eventAssistantExtraTest',
+          type: {
+            name: 'eventAssistantExtraTest',
+            label: 'Event Assistant With Additional Features',
+            properties: [],
+            platforms: [],
+          },
+          features: [], // collectiveVoice was explicitly disabled — not present in array
+        };
+
+        const user = userEvent.setup();
+        await renderAndGoToStep3(user, eventWithFeatureDisabled);
+
+        const collectiveVoiceCheckbox = screen.getByRole('checkbox', { name: /collective voice/i });
+        expect(collectiveVoiceCheckbox).not.toBeChecked();
+      });
+
+      it('includes a newly enabled feature in the payload alongside pre-existing ones', async () => {
+        const user = userEvent.setup();
+        // Start with only liveTranscript; enable autoSummary during edit
+        await renderAndGoToStep3(user);
+
+        await user.click(screen.getByRole('checkbox', { name: /auto summary/i }));
+
+        await submitFromStep3(user);
+
+        await waitFor(() => {
+          expect(updateConversation).toHaveBeenCalledWith(
+            'conv-edit-123',
+            expect.objectContaining({
+              features: expect.arrayContaining([
+                { name: 'liveTranscript', config: { transcriptDelay: 10 } },
+                { name: 'autoSummary', config: {} },
+              ]),
+            }),
+          );
+        });
+      });
+    });
+
+    it('redirects to the view page after a successful save in edit mode', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        render(<EventCreationForm mode="edit" initialEvent={mockInitialEvent} />);
+      });
+
+      await waitFor(() => screen.getByLabelText(/Event Name/i));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Nextspace'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Customize your conversation settings'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('About the Speakers'));
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => screen.getByText('Reading & Resources'));
+
+      await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/admin/backChannel/view/conv-edit-123');
+      });
+    });
+
+    describe('Step payload verification', () => {
+      // Navigate to a specific step starting from the rendered edit form.
+      const renderAndGoToStep = async (
+        user: ReturnType<typeof userEvent.setup>,
+        step: 1 | 2 | 3 | 4 | 5,
+        event: any = mockInitialEvent,
+      ) => {
+        await act(async () => {
+          render(<EventCreationForm mode="edit" initialEvent={event} />);
+        });
+        await waitFor(() => screen.getByLabelText(/Event Name/i));
+        if (step >= 2) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('Nextspace'));
+        }
+        if (step >= 3) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('Customize your conversation settings'));
+        }
+        if (step >= 4) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('About the Speakers'));
+        }
+        if (step >= 5) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('Reading & Resources'));
+        }
+      };
+
+      // Continue through remaining steps from the given step and submit the form.
+      const submitFromStep = async (user: ReturnType<typeof userEvent.setup>, fromStep: 1 | 2 | 3 | 4 | 5) => {
+        if (fromStep <= 1) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('Nextspace'));
+        }
+        if (fromStep <= 2) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('Customize your conversation settings'));
+        }
+        if (fromStep <= 3) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('About the Speakers'));
+        }
+        if (fromStep <= 4) {
+          await user.click(screen.getByRole('button', { name: /next/i }));
+          await waitFor(() => screen.getByText('Reading & Resources'));
+        }
+        await user.click(screen.getByRole('button', { name: /save changes/i }));
+      };
+
+      describe('Step 1 — event details', () => {
+        it('includes the updated event name in the payload', async () => {
+          const user = userEvent.setup();
+          await renderAndGoToStep(user, 1);
+
+          const nameInput = screen.getByLabelText(/Event Name/i);
+          await user.clear(nameInput);
+          await user.type(nameInput, 'Updated Event Name');
+
+          await submitFromStep(user, 1);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({ name: 'Updated Event Name' }),
+            );
+          });
+        });
+
+        it('includes the updated description in the payload', async () => {
+          const user = userEvent.setup();
+          await renderAndGoToStep(user, 1);
+
+          const descriptionInput = screen.getByLabelText(/Description/i);
+          await user.clear(descriptionInput);
+          await user.type(descriptionInput, 'A brand new description');
+
+          await submitFromStep(user, 1);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({ description: 'A brand new description' }),
+            );
+          });
+        });
+
+        it('includes the updated Zoom URL in the payload', async () => {
+          const user = userEvent.setup();
+          await renderAndGoToStep(user, 1);
+
+          const urlInput = screen.getByLabelText(/Zoom Meeting URL/i);
+          await user.clear(urlInput);
+          await user.type(urlInput, 'https://zoom.us/j/newmeeting');
+
+          await submitFromStep(user, 1);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                properties: expect.objectContaining({ zoomMeetingUrl: 'https://zoom.us/j/newmeeting' }),
+              }),
+            );
+          });
+        });
+
+        it('includes updated scheduled times in the payload when changed', async () => {
+          const user = userEvent.setup();
+          // Use an event without pre-filled times so we control what gets typed
+          const eventWithoutTimes: any = {
+            ...mockInitialEvent,
+            scheduledTime: undefined,
+            scheduledEndTime: undefined,
+          };
+          await renderAndGoToStep(user, 1, eventWithoutTimes);
+
+          const startTimeInput = screen.getAllByLabelText(/Meeting Day\/Time/i)[0];
+          await user.type(startTimeInput, futureStartTime);
+
+          const endTimeInput = screen.getAllByLabelText(/Meeting End Time/i)[0];
+          await user.type(endTimeInput, futureEndTime);
+
+          await submitFromStep(user, 1);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                scheduledTime: expect.any(String),
+                scheduledEndTime: expect.any(String),
+              }),
+            );
+          });
+        });
+
+        it('includes the updated topic ID in the payload', async () => {
+          const user = userEvent.setup();
+          // mockInitialEvent has topic: 'topic-1' — switch to topic-2
+          await renderAndGoToStep(user, 1);
+
+          const topicInput = screen.getByLabelText(/Select a series/i);
+          fireEvent.click(topicInput);
+          fireEvent.keyDown(topicInput, { key: 'ArrowDown' });
+          fireEvent.click(await screen.findByRole('option', { name: /Public Topic 2/i }));
+
+          await submitFromStep(user, 1);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({ topicId: 'topic-2' }),
+            );
+          });
+        });
+      });
+
+      describe('Step 2 — conversation setup', () => {
+        it('includes the updated platforms list in the payload', async () => {
+          const user = userEvent.setup();
+          // mockInitialEvent has platforms: ['zoom'] — also enable Nextspace
+          await renderAndGoToStep(user, 2);
+
+          await user.click(screen.getByRole('checkbox', { name: /nextspace/i }));
+
+          await submitFromStep(user, 2);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                platforms: expect.arrayContaining(['zoom', 'nextspace']),
+              }),
+            );
+          });
+        });
+      });
+
+      describe('Step 4 — speakers and moderators', () => {
+        it('reflects an edited speaker name and bio in the payload', async () => {
+          const user = userEvent.setup();
+          const eventWithSpeaker: any = {
+            ...mockInitialEvent,
+            presenters: [{ name: 'Original Speaker', bio: 'Original Bio' }],
+          };
+          await renderAndGoToStep(user, 4, eventWithSpeaker);
+
+          const nameInputs = screen.getAllByLabelText(/^Name$/i);
+          await user.clear(nameInputs[0]);
+          await user.type(nameInputs[0], 'Updated Speaker');
+
+          const bioInputs = screen.getAllByLabelText(/Bio/i);
+          await user.clear(bioInputs[0]);
+          await user.type(bioInputs[0], 'Updated Bio');
+
+          await submitFromStep(user, 4);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                presenters: expect.arrayContaining([
+                  expect.objectContaining({ name: 'Updated Speaker', bio: 'Updated Bio' }),
+                ]),
+              }),
+            );
+          });
+        });
+
+        it('includes a newly added speaker in the payload', async () => {
+          const user = userEvent.setup();
+          // mockInitialEvent has no presenters — form starts with one empty row
+          await renderAndGoToStep(user, 4);
+
+          await user.click(screen.getByRole('button', { name: /\+ Add Another Speaker/i }));
+          await waitFor(() => screen.getByText('Speaker 2'));
+
+          const nameInputs = screen.getAllByLabelText(/^Name$/i);
+          await user.type(nameInputs[0], 'First Speaker');
+          await user.type(nameInputs[1], 'Second Speaker');
+
+          await submitFromStep(user, 4);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                presenters: expect.arrayContaining([
+                  expect.objectContaining({ name: 'First Speaker' }),
+                  expect.objectContaining({ name: 'Second Speaker' }),
+                ]),
+              }),
+            );
+          });
+        });
+
+        it('excludes a removed speaker from the payload', async () => {
+          const user = userEvent.setup();
+          const eventWithTwoSpeakers: any = {
+            ...mockInitialEvent,
+            presenters: [
+              { name: 'Speaker One', bio: '' },
+              { name: 'Speaker Two', bio: '' },
+            ],
+          };
+          await renderAndGoToStep(user, 4, eventWithTwoSpeakers);
+          await waitFor(() => screen.getByText('Speaker 2'));
+
+          // With two pre-filled speakers, each has its own Remove button. Click the last
+          // one (Speaker Two's) so Speaker One is what remains in the payload.
+          const removeButtons = screen.getAllByRole('button', { name: /remove/i });
+          await user.click(removeButtons[removeButtons.length - 1]);
+          await waitFor(() => expect(screen.queryByText('Speaker 2')).not.toBeInTheDocument());
+
+          await submitFromStep(user, 4);
+
+          await waitFor(() => {
+            const call = (updateConversation as jest.Mock).mock.calls[0];
+            const presenters = call[1].presenters as { name: string }[];
+            expect(presenters).toHaveLength(1);
+            expect(presenters[0].name).toBe('Speaker One');
+          });
+        });
+
+        it('includes a newly added moderator in the payload', async () => {
+          const user = userEvent.setup();
+          await renderAndGoToStep(user, 4);
+
+          await user.click(screen.getByRole('button', { name: /\+ Add Moderators/i }));
+          await waitFor(() => screen.getByText('Moderator 1'));
+
+          const nameInputs = screen.getAllByLabelText(/^Name$/i);
+          await user.type(nameInputs[nameInputs.length - 1], 'New Moderator');
+
+          await submitFromStep(user, 4);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                moderators: expect.arrayContaining([expect.objectContaining({ name: 'New Moderator' })]),
+              }),
+            );
+          });
+        });
+
+        it('reflects an edited moderator name and bio in the payload', async () => {
+          const user = userEvent.setup();
+          const eventWithModerator: any = {
+            ...mockInitialEvent,
+            moderators: [{ name: 'Original Moderator', bio: 'Original Bio' }],
+          };
+          await renderAndGoToStep(user, 4, eventWithModerator);
+          await waitFor(() => screen.getByText('Moderator 1'));
+
+          const nameInputs = screen.getAllByLabelText(/^Name$/i);
+          const bioInputs = screen.getAllByLabelText(/Bio/i);
+          // Moderator fields appear after speaker fields — use the last Name/Bio inputs
+          await user.clear(nameInputs[nameInputs.length - 1]);
+          await user.type(nameInputs[nameInputs.length - 1], 'Updated Moderator');
+          await user.clear(bioInputs[bioInputs.length - 1]);
+          await user.type(bioInputs[bioInputs.length - 1], 'Updated Bio');
+
+          await submitFromStep(user, 4);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                moderators: expect.arrayContaining([
+                  expect.objectContaining({ name: 'Updated Moderator', bio: 'Updated Bio' }),
+                ]),
+              }),
+            );
+          });
+        });
+
+        it('includes alternateName for speakers and moderators in the payload', async () => {
+          const user = userEvent.setup();
+          const eventWithPeople: any = {
+            ...mockInitialEvent,
+            presenters: [{ name: 'Dr. Smith', bio: '' }],
+            moderators: [{ name: 'Ms. Jones', bio: '' }],
+          };
+          await renderAndGoToStep(user, 4, eventWithPeople);
+          await waitFor(() => screen.getByText('Moderator 1'));
+
+          const alternateNameInputs = screen.getAllByLabelText(/Alternate Name/i);
+          // First alternate name input belongs to the speaker, second to the moderator
+          await user.type(alternateNameInputs[0], 'John Smith');
+          await user.type(alternateNameInputs[1], 'Alice Jones');
+
+          await submitFromStep(user, 4);
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                presenters: expect.arrayContaining([expect.objectContaining({ alternateName: 'John Smith' })]),
+                moderators: expect.arrayContaining([expect.objectContaining({ alternateName: 'Alice Jones' })]),
+              }),
+            );
+          });
+        });
+
+        it('excludes a removed moderator from the payload', async () => {
+          const user = userEvent.setup();
+          const eventWithModerator: any = {
+            ...mockInitialEvent,
+            moderators: [{ name: 'Existing Moderator', bio: '' }],
+          };
+          await renderAndGoToStep(user, 4, eventWithModerator);
+          await waitFor(() => screen.getByText('Moderator 1'));
+
+          // showModerators is true because the event has a pre-filled moderator.
+          // The Remove button for the moderator section removes the whole section.
+          const removeButtons = screen.getAllByRole('button', { name: /remove/i });
+          await user.click(removeButtons[removeButtons.length - 1]);
+
+          await submitFromStep(user, 4);
+
+          await waitFor(() => {
+            const call = (updateConversation as jest.Mock).mock.calls[0];
+            expect(call[1].moderators ?? []).toHaveLength(0);
+          });
+        });
+      });
+
+      describe('Step 5 — resources', () => {
+        it('includes a newly added resource in the payload', async () => {
+          const user = userEvent.setup();
+          await renderAndGoToStep(user, 5);
+
+          await user.type(screen.getByLabelText(/^Title/i), 'A New Resource');
+
+          await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+          await waitFor(() => {
+            expect(updateConversation).toHaveBeenCalledWith(
+              'conv-edit-123',
+              expect.objectContaining({
+                resources: expect.arrayContaining([expect.objectContaining({ title: 'A New Resource' })]),
+              }),
+            );
+          });
+        });
+
+        it('excludes a resource whose title has been cleared from the payload', async () => {
+          const user = userEvent.setup();
+          const eventWithResource: any = {
+            ...mockInitialEvent,
+            resources: [{ title: 'Existing Resource', url: '' }],
+          };
+          await renderAndGoToStep(user, 5, eventWithResource);
+
+          const titleInput = screen.getByLabelText(/^Title/i);
+          await user.clear(titleInput);
+
+          await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+          await waitFor(() => {
+            const call = (updateConversation as jest.Mock).mock.calls[0];
+            expect(call[1].resources ?? []).toHaveLength(0);
+          });
+        });
+      });
     });
   });
 

--- a/__tests__/components/EventCreationForm.Test.tsx
+++ b/__tests__/components/EventCreationForm.Test.tsx
@@ -2889,10 +2889,9 @@ describe('EventCreationForm Component', () => {
       });
     });
 
-    describe('Catalyst timing in edit mode', () => {
-      /* Catalyst's minContributionInterval is fixed once the event is created. In edit
-         mode the organizer can only toggle the feature on or off. The input is hidden,
-         and the saved value goes back in the update payload unchanged. */
+    describe('Feature sub-property inputs in edit mode', () => {
+      /* All feature sub-properties (timing intervals, etc.) are editable in edit mode,
+         the same as in create mode. */
       const mockCatalystEvent: any = {
         ...mockInitialEvent,
         platforms: ['zoom'],
@@ -2903,10 +2902,6 @@ describe('EventCreationForm Component', () => {
           properties: [],
           platforms: [],
         },
-        /* Explicitly disable Collective Voice and Librarian. They share the same
-           "Minimum Minutes Between Contributions" label as catalyst, so leaving them
-           at their default of true would cause the hide-input assertion below to find
-           the wrong field. */
         features: [
           { name: 'catalyst', enabled: true, config: { minContributionInterval: 7 } },
           { name: 'collectiveVoice', enabled: false, config: {} },
@@ -2925,10 +2920,7 @@ describe('EventCreationForm Component', () => {
         await waitFor(() => screen.getByText('Customize your conversation settings'));
       };
 
-      it('still shows Collective Voice and Reading Recommendations sub-fields in edit mode', async () => {
-        // Regression: the catalyst-only hide rule should not affect peer features that
-        // share the same minContributionInterval shape. Collective Voice and Librarian's
-        // sub-properties stay editable in edit mode.
+      it('shows sub-property inputs for all enabled features in edit mode', async () => {
         const eventWithAllThree: any = {
           ...mockInitialEvent,
           platforms: ['zoom'],
@@ -2940,6 +2932,7 @@ describe('EventCreationForm Component', () => {
             platforms: [],
           },
           features: [
+            { name: 'catalyst', enabled: true, config: { minContributionInterval: 7 } },
             { name: 'collectiveVoice', enabled: true, config: { minContributionInterval: 5 } },
             { name: 'librarian', enabled: true, config: { recommendationsPerInterval: 3 } },
           ],
@@ -2948,23 +2941,16 @@ describe('EventCreationForm Component', () => {
         const user = userEvent.setup();
         await goToStep3(user, eventWithAllThree);
 
-        // Collective Voice's sub-property must render with the saved value
-        const cvInputs = screen.getAllByLabelText(/Minimum Minutes Between Contributions/i) as HTMLInputElement[];
-        expect(cvInputs.length).toBeGreaterThanOrEqual(1);
-        expect(cvInputs.some((i) => i.value === '5')).toBe(true);
+        // Catalyst's sub-property must render with the saved value
+        const intervalInputs = screen.getAllByLabelText(/Minimum Minutes Between Contributions/i) as HTMLInputElement[];
+        expect(intervalInputs.some((i) => i.value === '7')).toBe(true);
+
+        // Collective Voice's sub-property must also render
+        expect(intervalInputs.some((i) => i.value === '5')).toBe(true);
 
         // Librarian's sub-property must render with the saved value
         const libInput = screen.getByLabelText(/Number of Reading Recommendations per Interval/i) as HTMLInputElement;
         expect(libInput.value).toBe('3');
-      });
-
-      it('hides the catalyst timing input in edit mode even when the feature is enabled', async () => {
-        const user = userEvent.setup();
-        await goToStep3(user, mockCatalystEvent);
-
-        // Catalyst is checked, but its sub-property input must not render in edit mode
-        expect(screen.getByRole('checkbox', { name: /catalyst/i })).toBeChecked();
-        expect(screen.queryByLabelText(/Minimum Minutes Between Contributions/i)).not.toBeInTheDocument();
       });
 
       it('preserves the saved catalyst timing in the payload when re-saved unchanged', async () => {

--- a/__tests__/pages/admin/events.test.tsx
+++ b/__tests__/pages/admin/events.test.tsx
@@ -915,6 +915,13 @@ describe('Events Page - Edit button', () => {
     expect(screen.queryByLabelText('Edit event')).not.toBeInTheDocument();
   });
 
+  it('does not show an edit button for an event with no type set', async () => {
+    /* Legacy events may have no type object, which would produce /admin/undefined/edit/<id>
+       if the edit button were shown. The canEdit guard prevents this. */
+    await renderWithEvent(makeConversation({ type: undefined }));
+    expect(screen.queryByLabelText('Edit event')).not.toBeInTheDocument();
+  });
+
   it('navigates to the edit page when the edit button is clicked', async () => {
     const user = userEvent.setup();
     await renderWithEvent(makeConversation({}));

--- a/__tests__/pages/admin/events.test.tsx
+++ b/__tests__/pages/admin/events.test.tsx
@@ -60,9 +60,10 @@ const mockConversations = [
 ];
 
 // Mock dependencies
+const mockPush = jest.fn();
 jest.mock('next/router', () => ({
   useRouter: () => ({
-    push: jest.fn(),
+    push: mockPush,
   }),
 }));
 
@@ -850,5 +851,74 @@ describe('Events Page - Event Ownership', () => {
 
       alertMock.mockRestore();
     });
+  });
+});
+
+describe('Events Page - Edit button', () => {
+  const mockUserId = 'user-123';
+  const futureTime = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+  const pastTime = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+
+  const makeConversation = (overrides: object) => ({
+    id: 'ev-1',
+    name: 'Editable Event',
+    active: false,
+    scheduledTime: futureTime,
+    createdAt: futureTime,
+    owner: mockUserId,
+    platformTypes: [],
+    type: { name: 'backChannel', label: 'Back Channel' },
+    eventUrls: { zoom: null, moderator: [], participant: [] },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getConversation as jest.Mock).mockReset();
+    (useSessionJoin as jest.Mock).mockReturnValue({ userId: mockUserId });
+  });
+
+  const renderWithEvent = async (conv: object) => {
+    (Request as jest.Mock).mockResolvedValue([conv]);
+    (getConversation as jest.Mock).mockResolvedValueOnce(conv);
+    await act(async () => {
+      render(<EventsPage authType="user" />);
+    });
+    await waitFor(() => expect(screen.getByText('Editable Event')).toBeInTheDocument());
+  };
+
+  it('shows an edit button for a future inactive event owned by the current user', async () => {
+    await renderWithEvent(makeConversation({}));
+    expect(screen.getByLabelText('Edit event')).toBeInTheDocument();
+  });
+
+  it('does not show an edit button for an active event', async () => {
+    await renderWithEvent(makeConversation({ active: true }));
+    expect(screen.queryByLabelText('Edit event')).not.toBeInTheDocument();
+  });
+
+  it('does not show an edit button for an event owned by another user', async () => {
+    await renderWithEvent(makeConversation({ owner: 'someone-else' }));
+    expect(screen.queryByLabelText('Edit event')).not.toBeInTheDocument();
+  });
+
+  it('does not show an edit button for a past event', async () => {
+    // Past events are filtered out by filterConversations, so no card renders.
+    // We just verify no edit button appears anywhere on the page.
+    const pastConv = makeConversation({ scheduledTime: pastTime });
+    (Request as jest.Mock).mockResolvedValue([pastConv]);
+    (getConversation as jest.Mock).mockResolvedValueOnce(pastConv);
+    await act(async () => {
+      render(<EventsPage authType="user" />);
+    });
+    await waitFor(() => expect(screen.getByText('No upcoming events')).toBeInTheDocument());
+    expect(screen.queryByLabelText('Edit event')).not.toBeInTheDocument();
+  });
+
+  it('navigates to the edit page when the edit button is clicked', async () => {
+    const user = userEvent.setup();
+    await renderWithEvent(makeConversation({}));
+    await user.click(await screen.findByLabelText('Edit event'));
+    expect(mockPush).toHaveBeenCalledWith('/admin/backChannel/edit/ev-1');
   });
 });

--- a/components/Event/Status.tsx
+++ b/components/Event/Status.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Button, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
+import { useRouter } from 'next/router';
 import { SendData } from '../../utils';
 import { Conversation } from '../../types.internal';
+import SessionManager from '../../utils/SessionManager';
 
 /**
  * EventStatus component
@@ -15,8 +17,13 @@ import { Conversation } from '../../types.internal';
 export const EventStatus: React.FC<{
   conversationData: Conversation;
 }> = ({ conversationData }) => {
+  const router = useRouter();
   const [startingEvent, setStartingEvent] = React.useState(false);
   const [eventStarted, setEventStarted] = React.useState(false);
+
+  const userId = SessionManager.get().getSessionInfo()?.userId;
+  const ownerId = typeof conversationData.owner === 'string' ? conversationData.owner : (conversationData.owner as any)?.id;
+  const canEdit = !eventStarted && !conversationData.active && !!userId && userId === ownerId;
 
   // Format list with "and" before last item
   const formatList = (items: string[]) => {
@@ -107,7 +114,17 @@ export const EventStatus: React.FC<{
             ))}
           </>
         )}
-        <StartEventButton />
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', mt: 2 }}>
+          <StartEventButton />
+          {canEdit && (
+            <Button
+              variant="outlined"
+              onClick={() => router.push(`/admin/${conversationData.type.name}/edit/${conversationData.id}`)}
+            >
+              Edit Event
+            </Button>
+          )}
+        </Box>
         {eventStarted && <p className="mt-2">The event has started!</p>}
       </div>
     </div>

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -1666,11 +1666,6 @@ export const EventCreationForm: React.FC<{
                           }
                         />
                         {dynamicPropertyValues[feature.name] &&
-                          /* Catalyst timing is fixed once an event is created. In edit mode
-                             the organizer can only toggle the feature on or off. The saved
-                             value stays in dynamicPropertyValues and goes back in the
-                             update payload unchanged. */
-                          !(mode === 'edit' && feature.name === 'catalyst') &&
                           feature.properties?.map((prop) => renderDynamicPropertyField(prop, feature.name))}
                       </Box>
                     ))}

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -24,6 +24,11 @@ import {
   useTheme,
   useMediaQuery,
   MobileStepper,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
 } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -76,6 +81,7 @@ export const EventCreationForm: React.FC<{
   const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
   const [selectedConvType, setSelectedConvType] = useState<string | null>(null);
   const [showAgentTypeHint, setShowAgentTypeHint] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [supportedModels, setSupportedModels] = useState<components['schemas']['LlmModelDetails'][] | null>(null);
   const [availablePlatforms, setAvailablePlatforms] = useState<components['schemas']['PlatformConfig'][] | null>(null);
   const [conversationTypes, setConversationTypes] = useState<components['schemas']['ConversationType'][] | null>(null);
@@ -171,9 +177,55 @@ export const EventCreationForm: React.FC<{
   // Stores event's existing dynamic property values so Effect 1 can merge them
   // with type defaults after setSelectedConvType triggers it to re-run.
   const preFillPending = useRef<Record<string, any> | null>(null);
+  /** Snapshot of all editable state at the moment pre-fill settled. Used to detect real changes vs. reverts. */
+  const cleanSnapshot = useRef<string | null>(null);
 
   const setFieldFocus = (fieldName: string) => {
     (formRef.current?.elements.namedItem(fieldName) as HTMLElement)?.focus();
+  };
+
+  const navigateToView = () => {
+    const typeName = initialEvent?.type?.name ?? (initialEvent as any)?.conversationType;
+    router.push(`/admin/${typeName}/view/${initialEvent?.id}`);
+  };
+
+  /*
+   * Normalizes a date string to the same canonical form DateTimePicker.onChange produces
+   * (UTC ISO via dayjs().toISOString()). Without this, the API's local-tz ISO and a
+   * user-edited-then-reverted value would serialize differently and trigger a false dirty.
+   */
+  const normalizeDate = (s: string) => (s && dayjs(s).isValid() ? dayjs(s).toISOString() : (s ?? ''));
+
+  /*
+   * Serializes all user-editable form state into a stable JSON string for dirty-checking.
+   * Platforms are sorted so selection order doesn't cause false positives.
+   * PDF File objects are excluded (non-serializable); hasNewPdf handles them separately.
+   * `overrides` lets the initial capture pass values the corresponding state setter
+   * hasn't committed yet (e.g. dynamicPropertyValues during the pre-fill effect).
+   */
+  const serializeFormState = (overrides?: { dynamicPropertyValues?: Record<string, any> }) =>
+    JSON.stringify({
+      eventName,
+      eventDescription,
+      zoomMeetingUrl,
+      zoomMeetingTime: normalizeDate(zoomMeetingTime),
+      scheduledEndTime: normalizeDate(scheduledEndTime),
+      selectedConvType,
+      selectedPlatforms: [...selectedPlatforms].sort(),
+      selectedTopicId,
+      moderators,
+      speakers,
+      resources: resources.map(({ pdf: _pdf, ...r }) => r),
+      dynamicPropertyValues: overrides?.dynamicPropertyValues ?? dynamicPropertyValues,
+    });
+
+  const handleCancelEdit = () => {
+    const hasNewPdf = resources.some((r) => r.pdf);
+    if (hasNewPdf || serializeFormState() !== cleanSnapshot.current) {
+      setCancelDialogOpen(true);
+    } else {
+      navigateToView();
+    }
   };
 
   useEffect(() => {
@@ -243,11 +295,22 @@ export const EventCreationForm: React.FC<{
         if (preFillPending.current) {
           Object.assign(initialValues, preFillPending.current);
           preFillPending.current = null;
+          // Capture the clean snapshot here, using `initialValues` directly as the
+          // dynamicPropertyValues — the state setter below hasn't committed yet, so
+          // the closure's `dynamicPropertyValues` would be stale if we read it instead.
+          if (mode === 'edit' && cleanSnapshot.current === null) {
+            cleanSnapshot.current = serializeFormState({ dynamicPropertyValues: initialValues });
+          }
         }
 
         setDynamicPropertyValues(initialValues);
       }
     }
+    // The snapshot capture above reads several state variables (eventName, moderators, etc.)
+    // from the closure. Those intentionally are NOT in the dep array — this effect must only
+    // re-run when the conv type changes, not on every field edit. The snapshot is only written
+    // once (cleanSnapshot.current guards it), so stale-closure risk doesn't apply.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationTypes, selectedConvType]);
 
   useEffect(() => {
@@ -1995,47 +2058,68 @@ export const EventCreationForm: React.FC<{
               Back
             </Button>
 
-            {activeStep === steps.length - 1 ? (
-              <Button
-                type="button"
-                variant="contained"
-                disabled={formSubmitting}
-                onClick={(e) => {
-                  e.preventDefault();
-                  if (formRef.current) sendData(new FormData(formRef.current));
-                }}
-                sx={{
-                  ml: { xs: 1, sm: 0 },
-                  fontSize: { xs: '0.75rem', sm: '0.875rem' },
-                }}
-              >
-                {formSubmitting ? (
-                  <>
-                    <CircularProgress size={16} color="inherit" sx={{ mr: 1 }} />
-                    {mode === 'edit' ? 'Saving…' : 'Creating…'}
-                  </>
-                ) : mode === 'edit' ? (
-                  'Save Changes'
-                ) : (
-                  'Create Conversation'
-                )}
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                variant="contained"
-                onClick={(e) => {
-                  e.preventDefault();
-                  handleNext();
-                }}
-                sx={{ ml: { xs: 1, sm: 0 } }}
-              >
-                Next
-              </Button>
-            )}
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              {mode === 'edit' && (
+                <Button variant="outlined" color="inherit" onClick={handleCancelEdit} type="button">
+                  Cancel
+                </Button>
+              )}
+
+              {activeStep === steps.length - 1 ? (
+                <Button
+                  type="button"
+                  variant="contained"
+                  disabled={formSubmitting}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    if (formRef.current) sendData(new FormData(formRef.current));
+                  }}
+                  sx={{
+                    ml: { xs: 1, sm: 0 },
+                    fontSize: { xs: '0.75rem', sm: '0.875rem' },
+                  }}
+                >
+                  {formSubmitting ? (
+                    <>
+                      <CircularProgress size={16} color="inherit" sx={{ mr: 1 }} />
+                      {mode === 'edit' ? 'Saving…' : 'Creating…'}
+                    </>
+                  ) : mode === 'edit' ? (
+                    'Save Changes'
+                  ) : (
+                    'Create Conversation'
+                  )}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="contained"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleNext();
+                  }}
+                  sx={{ ml: { xs: 1, sm: 0 } }}
+                >
+                  Next
+                </Button>
+              )}
+            </Box>
           </Box>
         </Box>
       </Paper>
+
+      <Dialog open={cancelDialogOpen} onClose={() => setCancelDialogOpen(false)}>
+        <DialogTitle>Discard changes?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Your changes will be lost if you leave this page.</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCancelDialogOpen(false)}>Keep editing</Button>
+          <Button onClick={navigateToView} color="error">
+            Discard
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -3,6 +3,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import {
   Alert,
   Autocomplete,
+  Backdrop,
   Box,
   Button,
   Checkbox,
@@ -99,6 +100,7 @@ export const EventCreationForm: React.FC<{
   const [dynamicPropertyValues, setDynamicPropertyValues] = useState<Record<string, any>>({});
   const [formSubmitted, setFormSubmitted] = useState(false);
   const [formSubmitting, setFormSubmitting] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [pdfUploadWarnings, setPdfUploadWarnings] = useState<string[]>([]);
   const [conversationData, setConversationData] = useState<Conversation | null>(null);
@@ -126,6 +128,11 @@ export const EventCreationForm: React.FC<{
     description: '',
     citation: '',
     pdf: undefined as File | undefined,
+    /* id and hasPdf are only populated in edit mode, carried over from the server.
+       id lets updateResources match this entry to its DB record and preserve fileName.
+       hasPdf is the server's derived signal that a PDF is already attached. */
+    id: undefined as string | undefined,
+    hasPdf: false as boolean,
     required: false,
     participantVisible: true,
   });
@@ -458,6 +465,10 @@ export const EventCreationForm: React.FC<{
           description: r.description ?? '',
           citation: r.citation ?? '',
           pdf: undefined,
+          /* Carry over id (for server-side fileName matching on re-save) and hasPdf
+             (so the UI can show that a PDF is already attached). */
+          id: r.id as string | undefined,
+          hasPdf: !!(r as any).hasPdf,
           required: r.category === 'required',
           participantVisible: r.participantVisible ?? true,
         })),
@@ -658,6 +669,10 @@ export const EventCreationForm: React.FC<{
                 }));
               }
             }}
+            /* Blurring on scroll prevents the browser from treating the wheel event as
+               an increment/decrement on a focused number input. The mutation is silent,
+               so users often don't notice until the form submits the wrong value. */
+            onWheel={(e) => (e.target as HTMLInputElement).blur()}
           />
         );
 
@@ -1007,6 +1022,9 @@ export const EventCreationForm: React.FC<{
     const validResources = resources
       .filter((r) => r.title.trim() !== '')
       .map((r) => ({
+        /* Include the server-side id so updateResources can match this resource
+           to its existing DB entry and carry over fileName. Omitted for new resources. */
+        ...(r.id && { id: r.id }),
         source: 'speaker' as const,
         category: r.required ? ('required' as const) : ('suggested' as const),
         title: r.title.trim(),
@@ -1061,10 +1079,16 @@ export const EventCreationForm: React.FC<{
       });
     }
 
-    const features = (selectedType?.features ?? [])
-      .filter((feature) => Boolean(dynamicPropertyValues[feature.name]))
-      .map((feature) => {
-        const config: Record<string, any> = {};
+    /* Include every feature in the type definition, not just enabled ones.
+       Disabled features must be sent explicitly so the server can persist the
+       intent to disable (silence is ambiguous — it could mean "not set yet"
+       rather than "turned off"). User-controlled features (userControlled: true)
+       are not rendered in the admin form but their saved state still belongs
+       in the payload. */
+    const features = (selectedType?.features ?? []).map((feature) => {
+      const enabled = Boolean(dynamicPropertyValues[feature.name]);
+      const config: Record<string, any> = {};
+      if (enabled) {
         feature.properties?.forEach((prop) => {
           const value = dynamicPropertyValues[`${feature.name}.${prop.name}`];
           if (value !== undefined && value !== null && value !== '') {
@@ -1073,8 +1097,9 @@ export const EventCreationForm: React.FC<{
             config[prop.name] = prop.default;
           }
         });
-        return { name: feature.name, config };
-      });
+      }
+      return { name: feature.name, enabled, config };
+    });
 
     body = {
       ...body,
@@ -1083,20 +1108,62 @@ export const EventCreationForm: React.FC<{
     };
 
     setFormSubmitting(true);
+    setSaveStatus(mode === 'edit' ? 'Saving changes...' : 'Creating event...');
+
+    /* Upload PDFs for resources that have a file attached.
+       Matches local resources to response resources by title to get the resource ID,
+       then POSTs each PDF to the resource endpoint. Collects any upload failures so
+       they can be shown to the user without blocking navigation. */
+    const uploadPdfs = async (conversationId: string, responseResources: components['schemas']['Resource'][]) => {
+      const resourcesWithPdf = resources
+        .filter((r) => r.title.trim() !== '' && r.pdf)
+        .flatMap((r) => {
+          const match = responseResources.find((res) => res.title === r.title.trim());
+          return match?.id ? [{ pdf: r.pdf as File, resourceId: match.id }] : [];
+        });
+
+      if (resourcesWithPdf.length === 0) return;
+
+      const uploadResults = await Promise.allSettled(
+        resourcesWithPdf.map(({ pdf, resourceId }) => {
+          const formData = new FormData();
+          formData.append('pdf', pdf);
+          return SendData(`resources/${conversationId}/${resourceId}/pdf`, null, undefined, {
+            method: 'POST',
+            body: formData,
+          });
+        }),
+      );
+
+      const failures = uploadResults
+        .map((result, i) => ({ result, name: resourcesWithPdf[i].pdf.name }))
+        .filter(({ result }) => result.status === 'rejected' || (result.status === 'fulfilled' && result.value?.error))
+        .map(({ name }) => name);
+
+      if (failures.length > 0) {
+        setPdfUploadWarnings(failures);
+      }
+    };
 
     if (mode === 'edit' && initialEvent) {
       updateConversation(initialEvent.id!, body)
-        .then((data) => {
-          setFormSubmitting(false);
+        .then(async (data) => {
           if (!data || 'error' in data) {
+            setSaveStatus(null);
+            setFormSubmitting(false);
             setFormError((data as any)?.message?.message || 'Failed to save changes.');
             return;
           }
+          const hasPdfs = resources.some((r) => r.title.trim() !== '' && r.pdf);
+          if (hasPdfs) setSaveStatus('Uploading PDF...');
+          // Upload PDFs for any resources with a file attached, same as create mode.
+          await uploadPdfs(data.id as string, (data as any).resources ?? []);
           navigateToView();
         })
         .catch((error: Error) => {
-          setFormError(`Failed to save changes. (${error.message})`);
+          setSaveStatus(null);
           setFormSubmitting(false);
+          setFormError(`Failed to save changes. (${error.message})`);
         });
       return;
     }
@@ -1104,48 +1171,27 @@ export const EventCreationForm: React.FC<{
     Request('conversations/from-type', body)
       .then(async (data) => {
         if (!data) {
-          setFormError('Failed to send data. Please try again.');
+          setSaveStatus(null);
           setFormSubmitting(false);
+          setFormError('Failed to send data. Please try again.');
           return;
         }
         if ('error' in data) {
-          setFormError(data.message?.message || 'Failed to create conversation.');
+          setSaveStatus(null);
           setFormSubmitting(false);
+          setFormError(data.message?.message || 'Failed to create conversation.');
           return;
         }
 
-        // Upload PDFs for any resources that have one attached
         const conversationId = data.id as string;
         const responseResources: components['schemas']['Resource'][] = data.resources ?? [];
-        const resourcesWithPdf = resources
-          .filter((r) => r.title.trim() !== '' && r.pdf)
-          .flatMap((r) => {
-            const match = responseResources.find((res) => res.title === r.title.trim());
-            return match?.id ? [{ pdf: r.pdf as File, resourceId: match.id }] : [];
-          });
 
-        if (resourcesWithPdf.length > 0) {
-          const uploadResults = await Promise.allSettled(
-            resourcesWithPdf.map(({ pdf, resourceId }) => {
-              const formData = new FormData();
-              formData.append('pdf', pdf);
-              return SendData(`resources/${conversationId}/${resourceId}/pdf`, null, undefined, {
-                method: 'POST',
-                body: formData,
-              });
-            }),
-          );
+        const hasPdfs = resources.some((r) => r.title.trim() !== '' && r.pdf);
+        if (hasPdfs) setSaveStatus('Uploading PDF...');
+        // Upload PDFs for any resources with a file attached.
+        await uploadPdfs(conversationId, responseResources);
 
-          const failures = uploadResults
-            .map((result, i) => ({ result, name: resourcesWithPdf[i].pdf.name }))
-            .filter(({ result }) => result.status === 'rejected' || (result.status === 'fulfilled' && result.value?.error))
-            .map(({ name }) => name);
-
-          if (failures.length > 0) {
-            setPdfUploadWarnings(failures);
-          }
-        }
-
+        setSaveStatus(null);
         createConversationFromData(data).then((conversation) => {
           setConversationData(conversation);
           setFormSubmitted(true);
@@ -1153,8 +1199,9 @@ export const EventCreationForm: React.FC<{
       })
       .catch((error) => {
         console.error('Error sending data:', error);
-        setFormError(`Failed to send data. (${error.message})`);
+        setSaveStatus(null);
         setFormSubmitting(false);
+        setFormError(`Failed to send data. (${error.message})`);
       });
   };
 
@@ -1224,7 +1271,7 @@ export const EventCreationForm: React.FC<{
           </Snackbar>
         )}
 
-        <Box component="form" noValidate action="#" ref={formRef}>
+        <Box component="form" noValidate onSubmit={(e) => e.preventDefault()} ref={formRef}>
           {/* Step 1: Event Details */}
           {activeStep === 0 && (
             <Box>
@@ -1974,6 +2021,32 @@ export const EventCreationForm: React.FC<{
                           Remove
                         </Button>
                       </Box>
+                    ) : resource.hasPdf ? (
+                      /* hasPdf came back true from the server, so a PDF is attached.
+                         The API doesn't expose the filename, just the flag. Uploading a
+                         new file replaces it; re-saving without one keeps it. */
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                          p: 1.5,
+                          border: '1px solid rgba(0,0,0,0.12)',
+                          borderRadius: 1,
+                        }}
+                      >
+                        <Box sx={{ flex: 1 }}>
+                          <Typography variant="body2" fontWeight={500}>
+                            PDF already uploaded
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            Used as AI background context · Upload a new file to replace it
+                          </Typography>
+                        </Box>
+                        <Button size="small" onClick={() => document.getElementById(`pdf-upload-${index}`)?.click()}>
+                          Replace
+                        </Button>
+                      </Box>
                     ) : (
                       <Box
                         onClick={() => document.getElementById(`pdf-upload-${index}`)?.click()}
@@ -2125,6 +2198,16 @@ export const EventCreationForm: React.FC<{
           </Box>
         </Box>
       </Paper>
+
+      {/* Full-page overlay shown while saving or uploading — keeps the user informed
+          during async operations that block navigation */}
+      <Backdrop
+        open={saveStatus !== null}
+        sx={{ zIndex: (theme) => theme.zIndex.modal + 1, color: '#fff', flexDirection: 'column', gap: 2 }}
+      >
+        <CircularProgress color="inherit" />
+        <Typography variant="h6">{saveStatus}</Typography>
+      </Backdrop>
 
       <Dialog open={cancelDialogOpen} onClose={() => setCancelDialogOpen(false)}>
         <DialogTitle>Discard changes?</DialogTitle>

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -34,11 +34,20 @@ import { Request } from '../utils';
 import { EventStatus } from './';
 import { components } from '../types';
 import { Conversation } from '../types.internal';
-import { createConversationFromData, Api, SendData } from '../utils/Helpers';
+import { createConversationFromData, Api, SendData, updateConversation } from '../utils/Helpers';
 import SessionManager from '../utils/SessionManager';
 import { NewTopicForm, NewTopicFormValues } from './NewTopicForm';
 
 const steps = ['Event Details', 'Conversation Setup', 'Configuration', 'Speakers', 'Resources'];
+
+/**
+ * Produces a stable JSON string from an object by sorting its keys alphabetically.
+ * Used for enum radio-button comparisons so that key ordering differences (e.g. from
+ * MongoDB Mixed field serialization) don't cause a mismatch between the stored value
+ * and the radio option value built from validationKeys.
+ */
+const sortedStringify = (obj: Record<string, unknown>): string =>
+  JSON.stringify(Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b))));
 
 /**
  * EventCreationForm component
@@ -50,7 +59,10 @@ const steps = ['Event Details', 'Conversation Setup', 'Configuration', 'Speakers
  * Step 4: Moderators & Speakers (moderator and speaker information)
  * @returns A React component displaying the Event Creation form.
  */
-export const EventCreationForm: React.FC = ({}) => {
+export const EventCreationForm: React.FC<{
+  mode?: 'create' | 'edit';
+  initialEvent?: Conversation;
+}> = ({ mode = 'create', initialEvent }) => {
   const router = useRouter();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -63,6 +75,7 @@ export const EventCreationForm: React.FC = ({}) => {
 
   const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
   const [selectedConvType, setSelectedConvType] = useState<string | null>(null);
+  const [showAgentTypeHint, setShowAgentTypeHint] = useState(false);
   const [supportedModels, setSupportedModels] = useState<components['schemas']['LlmModelDetails'][] | null>(null);
   const [availablePlatforms, setAvailablePlatforms] = useState<components['schemas']['PlatformConfig'][] | null>(null);
   const [conversationTypes, setConversationTypes] = useState<components['schemas']['ConversationType'][] | null>(null);
@@ -155,6 +168,9 @@ export const EventCreationForm: React.FC = ({}) => {
   });
 
   const formRef = useRef<HTMLFormElement>(null);
+  // Stores event's existing dynamic property values so Effect 1 can merge them
+  // with type defaults after setSelectedConvType triggers it to re-run.
+  const preFillPending = useRef<Record<string, any> | null>(null);
 
   const setFieldFocus = (fieldName: string) => {
     (formRef.current?.elements.namedItem(fieldName) as HTMLElement)?.focus();
@@ -222,6 +238,13 @@ export const EventCreationForm: React.FC = ({}) => {
           });
         });
 
+        // In edit mode, the pre-fill effect stores the event's existing values here
+        // before calling setSelectedConvType, so we merge them over the type defaults.
+        if (preFillPending.current) {
+          Object.assign(initialValues, preFillPending.current);
+          preFillPending.current = null;
+        }
+
         setDynamicPropertyValues(initialValues);
       }
     }
@@ -288,6 +311,92 @@ export const EventCreationForm: React.FC = ({}) => {
     if (availableTopics === null) fetchTopics();
   }, [availableTopics]);
 
+  // In edit mode, pre-fill form state from the existing conversation once config has loaded.
+  // Config must be loaded first because setSelectedConvType triggers Effect 1, which needs
+  // conversationTypes and availablePlatforms to already be populated.
+  useEffect(() => {
+    if (mode !== 'edit' || !initialEvent || !conversationTypes || !availablePlatforms) return;
+
+    // Build the dynamic values from the saved event. These get stored in preFillPending
+    // so that Effect 1 (which runs after setSelectedConvType) can merge them with the
+    // type's defaults rather than replacing them.
+    const dynamicPrefill: Record<string, any> = {};
+    if (initialEvent.properties) {
+      Object.entries(initialEvent.properties).forEach(([key, value]) => {
+        if (key !== 'zoomMeetingUrl') dynamicPrefill[key] = value;
+      });
+    }
+    // Explicitly disable all features defined on the type first. This ensures that features
+    // absent from the saved event (i.e. the user disabled them) correctly override any
+    // default: true values that Effect 1 would otherwise apply.
+    const savedTypeName = initialEvent.type?.name ?? (initialEvent as any).conversationType;
+    const typeDefinition = conversationTypes?.find((t) => t.name === savedTypeName);
+    typeDefinition?.features?.forEach((featureDef) => {
+      dynamicPrefill[featureDef.name] = false;
+    });
+
+    initialEvent.features?.forEach((f) => {
+      dynamicPrefill[f.name] = f.enabled !== false;
+      Object.entries(f.config || {}).forEach(([key, value]) => {
+        dynamicPrefill[`${f.name}.${key}`] = value;
+      });
+    });
+    preFillPending.current = dynamicPrefill;
+
+    setEventName(initialEvent.name);
+    setEventDescription(initialEvent.description ?? '');
+    setZoomMeetingUrl((initialEvent.properties?.zoomMeetingUrl as string) ?? '');
+    setZoomMeetingTime(initialEvent.scheduledTime ?? '');
+    setScheduledEndTime((initialEvent as any).scheduledEndTime ?? '');
+    setSelectedPlatforms(initialEvent.platforms ?? []);
+
+    const rawTopic = initialEvent.topic;
+    const topicId =
+      typeof rawTopic === 'string' ? rawTopic : ((rawTopic as any)?.id ?? (rawTopic as any)?._id?.toString() ?? null);
+    if (topicId) setSelectedTopicId(topicId);
+
+    if (initialEvent.moderators?.length) {
+      setShowModerators(true);
+      setModerators(
+        initialEvent.moderators.map((m) => ({
+          name: m.name ?? '',
+          bio: m.bio ?? '',
+          alternateName: (m as any).alternateName,
+        })),
+      );
+    }
+
+    if (initialEvent.presenters?.length) {
+      setSpeakers(
+        initialEvent.presenters.map((p) => ({
+          name: p.name ?? '',
+          bio: p.bio ?? '',
+          alternateName: (p as any).alternateName,
+        })),
+      );
+    }
+
+    const apiResources = (initialEvent as any).resources ?? [];
+    if (apiResources.length) {
+      setResources(
+        apiResources.map((r: any) => ({
+          title: r.title ?? '',
+          authors: Array.isArray(r.authors) ? r.authors.join(', ') : (r.authors ?? ''),
+          year: r.year ?? '',
+          url: r.url ?? '',
+          description: r.description ?? '',
+          citation: r.citation ?? '',
+          pdf: undefined,
+          required: r.category === 'required',
+          participantVisible: r.participantVisible ?? true,
+        })),
+      );
+    }
+
+    // Triggers Effect 1, which will merge preFillPending into the initialized defaults.
+    setSelectedConvType(initialEvent.type?.name ?? null);
+  }, [mode, initialEvent, conversationTypes, availablePlatforms]);
+
   const validateStep1 = () => {
     // Check that required fields are present
     if (!eventName || eventName.trim() === '') {
@@ -317,7 +426,7 @@ export const EventCreationForm: React.FC = ({}) => {
       return false;
     }
 
-    if (zoomMeetingTime && new Date(zoomMeetingTime) < new Date(Date.now() + 10 * 60 * 1000)) {
+    if (mode !== 'edit' && zoomMeetingTime && new Date(zoomMeetingTime) < new Date(Date.now() + 10 * 60 * 1000)) {
       setFormError('Meeting Start Time must be at least 10 minutes from now');
       setZoomMeetingTimeErrorMessage('Meeting Start Time must be at least 10 minutes from now.');
       setZoomMeetingTimeHasError(true);
@@ -534,7 +643,7 @@ export const EventCreationForm: React.FC = ({}) => {
                 </Typography>
               )}
               <RadioGroup
-                value={JSON.stringify(value || {})}
+                value={sortedStringify(value || {})}
                 name={stateKey}
                 onChange={(e) => {
                   try {
@@ -578,7 +687,7 @@ export const EventCreationForm: React.FC = ({}) => {
                   return (
                     <div key={idx}>
                       <FormControlLabel
-                        value={JSON.stringify(optionValue)}
+                        value={sortedStringify(optionValue)}
                         control={<Radio />}
                         label={option.label || option.name || `Option ${idx + 1}`}
                       />
@@ -896,10 +1005,28 @@ export const EventCreationForm: React.FC = ({}) => {
     body = {
       ...body,
       properties,
-      ...(features.length > 0 && { features }),
+      features,
     };
 
     setFormSubmitting(true);
+
+    if (mode === 'edit' && initialEvent) {
+      updateConversation(initialEvent.id!, body)
+        .then((data) => {
+          setFormSubmitting(false);
+          if (!data || 'error' in data) {
+            setFormError((data as any)?.message?.message || 'Failed to save changes.');
+            return;
+          }
+          router.push(`/admin/${initialEvent.type.name}/view/${initialEvent.id}`);
+        })
+        .catch((error: Error) => {
+          setFormError(`Failed to save changes. (${error.message})`);
+          setFormSubmitting(false);
+        });
+      return;
+    }
+
     Request('conversations/from-type', body)
       .then(async (data) => {
         if (!data) {
@@ -974,7 +1101,7 @@ export const EventCreationForm: React.FC = ({}) => {
   return (
     <>
       <Typography variant="h4" className="text-center" gutterBottom>
-        Create Event
+        {mode === 'edit' ? 'Edit Event' : 'Create Event'}
       </Typography>
       <Paper elevation={3} sx={{ p: 4, maxWidth: 800, mx: 'auto', mt: 4, mb: 4 }}>
         {isMobile ? (
@@ -1118,8 +1245,8 @@ export const EventCreationForm: React.FC = ({}) => {
                       setSelectedTopicId(value?.id ?? null);
                       setTopicHasError(false);
                     }}
-                    renderOption={(props, option) => (
-                      <Box component="li" {...props} key={option.id}>
+                    renderOption={({ key, ...props }, option) => (
+                      <Box component="li" key={key} {...props}>
                         <Box sx={{ flexGrow: 1 }}>{option.name}</Box>
                         {option.private && (
                           <Typography variant="caption" sx={{ color: 'text.secondary', ml: 1 }}>
@@ -1306,6 +1433,14 @@ export const EventCreationForm: React.FC = ({}) => {
                   value={selectedConvType}
                   name="selectedConvType"
                   onChange={(e) => {
+                    if (selectedConvType && e.target.value !== selectedConvType) {
+                      setShowAgentTypeHint(true);
+                      // Preserve the current model selection so Effect 1 doesn't reset
+                      // it to the new type's default when it re-runs.
+                      if (dynamicPropertyValues.llmModel !== undefined) {
+                        preFillPending.current = { llmModel: dynamicPropertyValues.llmModel };
+                      }
+                    }
                     setSelectedConvType(e.target.value);
                     setFormGroupsErrors((prev) => ({
                       ...prev,
@@ -1334,6 +1469,11 @@ export const EventCreationForm: React.FC = ({}) => {
                     </div>
                   ))}
                 </RadioGroup>
+                {showAgentTypeHint && (
+                  <Alert severity="info" sx={{ mt: 1 }}>
+                    Changing the agent type will also update the bot name — you can customize it on the next step.
+                  </Alert>
+                )}
               </FormControl>
             </Box>
           )}
@@ -1469,6 +1609,7 @@ export const EventCreationForm: React.FC = ({}) => {
                     onChange={(e) => updateSpeaker(index, 'alternateName', e.target.value)}
                     fullWidth
                     variant="outlined"
+                    margin="dense"
                     placeholder="Separate multiple names with commas, e.g. Jon, Dr. Smith"
                   />
                   <TextField
@@ -1567,6 +1708,7 @@ export const EventCreationForm: React.FC = ({}) => {
                           onChange={(e) => updateModerator(index, 'alternateName', e.target.value)}
                           fullWidth
                           variant="outlined"
+                          margin="dense"
                           placeholder="Separate multiple names with commas, e.g. Jon, Dr. Smith"
                         />
                         <TextField
@@ -1870,8 +2012,10 @@ export const EventCreationForm: React.FC = ({}) => {
                 {formSubmitting ? (
                   <>
                     <CircularProgress size={16} color="inherit" sx={{ mr: 1 }} />
-                    Creating…
+                    {mode === 'edit' ? 'Saving…' : 'Creating…'}
                   </>
+                ) : mode === 'edit' ? (
+                  'Save Changes'
                 ) : (
                   'Create Conversation'
                 )}

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -174,10 +174,12 @@ export const EventCreationForm: React.FC<{
   });
 
   const formRef = useRef<HTMLFormElement>(null);
-  // Stores event's existing dynamic property values so Effect 1 can merge them
-  // with type defaults after setSelectedConvType triggers it to re-run.
+  /* Holds the saved event's field values while the form initializes. In edit
+     mode, we stash these here before setting the conversation type. The
+     type-change effect picks them up and merges them with the type's defaults
+     instead of overwriting them. */
   const preFillPending = useRef<Record<string, any> | null>(null);
-  /** Snapshot of all editable state at the moment pre-fill settled. Used to detect real changes vs. reverts. */
+  /** Snapshot of the form state once the saved event has been loaded in. Used to detect real changes vs. a user editing then reverting a field. */
   const cleanSnapshot = useRef<string | null>(null);
 
   const setFieldFocus = (fieldName: string) => {
@@ -189,20 +191,19 @@ export const EventCreationForm: React.FC<{
     router.push(`/admin/${typeName}/view/${initialEvent?.id}`);
   };
 
-  /*
-   * Normalizes a date string to the same canonical form DateTimePicker.onChange produces
-   * (UTC ISO via dayjs().toISOString()). Without this, the API's local-tz ISO and a
-   * user-edited-then-reverted value would serialize differently and trigger a false dirty.
-   */
+  /* Converts a date string to UTC ISO so both sides of a dirty-check compare
+     in the same format. The API may return dates with a timezone offset (e.g.
+     "+00:00") rather than "Z". Without this, a date the user didn't touch
+     still looks different from what DateTimePicker writes, and Cancel would
+     incorrectly show the unsaved-changes warning. */
   const normalizeDate = (s: string) => (s && dayjs(s).isValid() ? dayjs(s).toISOString() : (s ?? ''));
 
-  /*
-   * Serializes all user-editable form state into a stable JSON string for dirty-checking.
-   * Platforms are sorted so selection order doesn't cause false positives.
-   * PDF File objects are excluded (non-serializable); hasNewPdf handles them separately.
-   * `overrides` lets the initial capture pass values the corresponding state setter
-   * hasn't committed yet (e.g. dynamicPropertyValues during the pre-fill effect).
-   */
+  /* Captures all editable form fields as a JSON string for dirty-checking.
+     Platforms are sorted so adding then removing one in the same session
+     doesn't look like a change. PDF files are skipped since they can't be
+     serialized; hasNewPdf covers those separately. The overrides param lets
+     the initial snapshot pass dynamicPropertyValues directly, because the
+     state setter hasn't committed yet when we first call this. */
   const serializeFormState = (overrides?: { dynamicPropertyValues?: Record<string, any> }) =>
     JSON.stringify({
       eventName,
@@ -290,14 +291,15 @@ export const EventCreationForm: React.FC<{
           });
         });
 
-        // In edit mode, the pre-fill effect stores the event's existing values here
-        // before calling setSelectedConvType, so we merge them over the type defaults.
+        /* In edit mode, the pre-fill effect stores the saved event's values
+           here before setting the conversation type. We merge them on top of
+           the type's defaults rather than overwriting. */
         if (preFillPending.current) {
           Object.assign(initialValues, preFillPending.current);
           preFillPending.current = null;
-          // Capture the clean snapshot here, using `initialValues` directly as the
-          // dynamicPropertyValues — the state setter below hasn't committed yet, so
-          // the closure's `dynamicPropertyValues` would be stale if we read it instead.
+          /* Record the baseline form state here, passing initialValues directly
+             instead of reading dynamicPropertyValues from the closure. The state
+             setter hasn't committed yet at this point, so the closure value is stale. */
           if (mode === 'edit' && cleanSnapshot.current === null) {
             cleanSnapshot.current = serializeFormState({ dynamicPropertyValues: initialValues });
           }
@@ -306,10 +308,11 @@ export const EventCreationForm: React.FC<{
         setDynamicPropertyValues(initialValues);
       }
     }
-    // The snapshot capture above reads several state variables (eventName, moderators, etc.)
-    // from the closure. Those intentionally are NOT in the dep array — this effect must only
-    // re-run when the conv type changes, not on every field edit. The snapshot is only written
-    // once (cleanSnapshot.current guards it), so stale-closure risk doesn't apply.
+    /* This effect reads eventName, moderators, and other state from the closure,
+       but those are left out of the dependency array on purpose. The effect only
+       needs to re-run when the conversation type changes, not on every field edit.
+       The snapshot is written exactly once (cleanSnapshot guards it), so reading a
+       stale closure value at that moment is safe. */
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationTypes, selectedConvType]);
 
@@ -374,24 +377,28 @@ export const EventCreationForm: React.FC<{
     if (availableTopics === null) fetchTopics();
   }, [availableTopics]);
 
-  // In edit mode, pre-fill form state from the existing conversation once config has loaded.
-  // Config must be loaded first because setSelectedConvType triggers Effect 1, which needs
-  // conversationTypes and availablePlatforms to already be populated.
+  /* Populates the form with the saved event's data when the user opens an
+     existing event to edit. We wait until conversation types and platforms
+     have loaded before running this, because setting the conversation type
+     triggers a separate effect that needs those lists to be ready. */
   useEffect(() => {
     if (mode !== 'edit' || !initialEvent || !conversationTypes || !availablePlatforms) return;
 
-    // Build the dynamic values from the saved event. These get stored in preFillPending
-    // so that Effect 1 (which runs after setSelectedConvType) can merge them with the
-    // type's defaults rather than replacing them.
+    /* Build the saved event's dynamic field values (bot name, model, feature
+       toggles, etc.) and store them in preFillPending. Setting the conversation
+       type below triggers another effect that initializes all dynamic fields from
+       the type definition. That effect merges these saved values on top of the
+       defaults rather than replacing them. */
     const dynamicPrefill: Record<string, any> = {};
     if (initialEvent.properties) {
       Object.entries(initialEvent.properties).forEach(([key, value]) => {
         if (key !== 'zoomMeetingUrl') dynamicPrefill[key] = value;
       });
     }
-    // Explicitly disable all features defined on the type first. This ensures that features
-    // absent from the saved event (i.e. the user disabled them) correctly override any
-    // default: true values that Effect 1 would otherwise apply.
+    /* Mark all of the type's features as disabled before merging in the saved
+       event's feature list. Without this, any feature the organizer previously
+       turned off would be absent from the saved array, and the type-change effect
+       would re-enable it because the type definition has default: true. */
     const savedTypeName = initialEvent.type?.name ?? (initialEvent as any).conversationType;
     const typeDefinition = conversationTypes?.find((t) => t.name === savedTypeName);
     typeDefinition?.features?.forEach((featureDef) => {
@@ -456,8 +463,8 @@ export const EventCreationForm: React.FC<{
       );
     }
 
-    // Triggers Effect 1, which will merge preFillPending into the initialized defaults.
-    setSelectedConvType(initialEvent.type?.name ?? null);
+    // Setting the conversation type triggers the type-change effect, which merges preFillPending into the defaults.
+    setSelectedConvType(initialEvent.type?.name ?? (initialEvent as any).conversationType ?? null);
   }, [mode, initialEvent, conversationTypes, availablePlatforms]);
 
   const validateStep1 = () => {
@@ -1081,7 +1088,7 @@ export const EventCreationForm: React.FC<{
             setFormError((data as any)?.message?.message || 'Failed to save changes.');
             return;
           }
-          router.push(`/admin/${initialEvent.type.name}/view/${initialEvent.id}`);
+          navigateToView();
         })
         .catch((error: Error) => {
           setFormError(`Failed to save changes. (${error.message})`);
@@ -1366,7 +1373,7 @@ export const EventCreationForm: React.FC<{
                 <DateTimePicker
                   label="Meeting Day/Time"
                   value={zoomMeetingTime ? dayjs(zoomMeetingTime) : null}
-                  minDateTime={dayjs().add(10, 'minute')}
+                  minDateTime={mode === 'edit' ? undefined : dayjs().add(10, 'minute')}
                   onChange={(newValue) => {
                     const value = newValue?.isValid() ? newValue.toISOString() : '';
                     setZoomMeetingTime(value);
@@ -1498,8 +1505,10 @@ export const EventCreationForm: React.FC<{
                   onChange={(e) => {
                     if (selectedConvType && e.target.value !== selectedConvType) {
                       setShowAgentTypeHint(true);
-                      // Preserve the current model selection so Effect 1 doesn't reset
-                      // it to the new type's default when it re-runs.
+                      /* Save the current model before switching conversation types. The
+                         type-change effect re-initializes all dynamic fields from the new
+                         type's defaults, which would overwrite whatever model the user had
+                         already selected. */
                       if (dynamicPropertyValues.llmModel !== undefined) {
                         preFillPending.current = { llmModel: dynamicPropertyValues.llmModel };
                       }

--- a/components/EventCreationForm.tsx
+++ b/components/EventCreationForm.tsx
@@ -395,14 +395,15 @@ export const EventCreationForm: React.FC<{
         if (key !== 'zoomMeetingUrl') dynamicPrefill[key] = value;
       });
     }
-    /* Mark all of the type's features as disabled before merging in the saved
-       event's feature list. Without this, any feature the organizer previously
-       turned off would be absent from the saved array, and the type-change effect
-       would re-enable it because the type definition has default: true. */
+    /* Start each feature at its type default. The saved event's features array
+       overrides this below, but features that aren't in the array stay at the
+       default. This matches what getFeatures() in the backend does for legacy events
+       whose features were never persisted, and for events created before a feature
+       was added to the type. */
     const savedTypeName = initialEvent.type?.name ?? (initialEvent as any).conversationType;
     const typeDefinition = conversationTypes?.find((t) => t.name === savedTypeName);
     typeDefinition?.features?.forEach((featureDef) => {
-      dynamicPrefill[featureDef.name] = false;
+      dynamicPrefill[featureDef.name] = Boolean(featureDef.default);
     });
 
     initialEvent.features?.forEach((f) => {
@@ -510,7 +511,10 @@ export const EventCreationForm: React.FC<{
       return false;
     }
 
-    if (zoomMeetingTime && !scheduledEndTime) {
+    /* In create mode, end time is required once start time is set. In edit mode
+       it's optional: the backend stores scheduledEndTime as an optional Date, so
+       events without one should still be editable. */
+    if (mode !== 'edit' && zoomMeetingTime && !scheduledEndTime) {
       setFormError('Meeting End Time is required when a start time is provided');
       return false;
     }
@@ -1615,6 +1619,11 @@ export const EventCreationForm: React.FC<{
                           }
                         />
                         {dynamicPropertyValues[feature.name] &&
+                          /* Catalyst timing is fixed once an event is created. In edit mode
+                             the organizer can only toggle the feature on or off. The saved
+                             value stays in dynamicPropertyValues and goes back in the
+                             update payload unchanged. */
+                          !(mode === 'edit' && feature.name === 'catalyst') &&
                           feature.properties?.map((prop) => renderDynamicPropertyField(prop, feature.name))}
                       </Box>
                     ))}

--- a/pages/admin/[type]/edit/[id].tsx
+++ b/pages/admin/[type]/edit/[id].tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { CircularProgress } from '@mui/material';
+import { CheckAuthHeader, getConversation } from '../../../../utils/Helpers';
+import { AuthType } from '../../../../types.internal';
+
+import { EventCreationForm } from '../../../../components';
+import { Conversation } from '../../../../types.internal';
+
+export const getServerSideProps = async (context: { req: any }) => {
+  return CheckAuthHeader(context.req.headers);
+};
+
+function EditEventScreen({ authType }: { authType: AuthType }) {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const [conversationData, setConversationData] = useState<Conversation | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const fetchConversationData = async () => {
+      try {
+        const data = await getConversation(id as string);
+        setConversationData(data);
+      } catch (error) {
+        console.error('Error fetching conversation data:', error);
+      }
+    };
+
+    fetchConversationData();
+  }, [id]);
+
+  return (
+    <div className="flex justify-center items-start">
+      <div className="mt-12 w-2/3">
+        {conversationData ? (
+          <EventCreationForm mode="edit" initialEvent={conversationData} />
+        ) : (
+          <div style={{ marginTop: 40 }}>
+            <CircularProgress />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default EditEventScreen;

--- a/pages/admin/events.tsx
+++ b/pages/admin/events.tsx
@@ -22,6 +22,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import EventIcon from '@mui/icons-material/Event';
 import ComputerIcon from '@mui/icons-material/Computer';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import ReportProblem from '@mui/icons-material/ReportProblem';
 import DownloadIcon from '@mui/icons-material/Download';
 import { components } from '../../types';
@@ -42,6 +43,7 @@ const EventCard = ({
   onDelete: (id: string) => void;
   currentUserId: string | null;
 }) => {
+  const router = useRouter();
   const [copiedLink, setCopiedLink] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -49,6 +51,10 @@ const EventCard = ({
 
   // Check if current user is the owner of this event
   const isOwner = currentUserId && event.owner === currentUserId;
+
+  // Edit is available for future, not-yet-started, owned events
+  const eventStarted = event.scheduledTime ? new Date(event.scheduledTime) <= new Date() : false;
+  const canEdit = isOwner && !event.active && !eventStarted;
 
   const handleCopyLink = async (url: string) => {
     try {
@@ -129,6 +135,18 @@ const EventCard = ({
                     className="text-gray-500 hover:text-blue-600"
                   >
                     {isDownloading ? <CircularProgress size={20} /> : <DownloadIcon fontSize="small" />}
+                  </IconButton>
+                </Tooltip>
+              )}
+              {canEdit && (
+                <Tooltip title="Edit event">
+                  <IconButton
+                    size="small"
+                    aria-label="Edit event"
+                    onClick={() => router.push(`/admin/${event.type?.name}/edit/${event.id}`)}
+                    className="text-gray-500 hover:text-blue-600"
+                  >
+                    <EditIcon fontSize="small" />
                   </IconButton>
                 </Tooltip>
               )}

--- a/pages/admin/events.tsx
+++ b/pages/admin/events.tsx
@@ -54,7 +54,7 @@ const EventCard = ({
 
   // Edit is available for future, not-yet-started, owned events
   const eventStarted = event.scheduledTime ? new Date(event.scheduledTime) <= new Date() : false;
-  const canEdit = isOwner && !event.active && !eventStarted;
+  const canEdit = isOwner && !event.active && !eventStarted && !!event.type?.name;
 
   const handleCopyLink = async (url: string) => {
     try {

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -358,6 +358,15 @@ export const getConversation = async (id: string): Promise<Conversation | null> 
   return await createConversationFromData(response);
 };
 
+/**
+ * Updates an existing conversation via the PUT endpoint.
+ * @param id - The conversation ID to update.
+ * @param fields - The fields to update (any user-settable conversation fields).
+ * @returns The updated conversation data, or error information.
+ */
+export const updateConversation = async (id: string, fields: object) =>
+  SendData('conversations', { id, ...fields }, undefined, undefined, 'PUT');
+
 export const createConversationFromData = async (data: components['schemas']['Conversation']): Promise<Conversation> => {
   const { conversationTypes, availablePlatforms, conversationBotName } = await Api.get().GetConfig();
 


### PR DESCRIPTION
## What is in this PR?

Events couldn't be edited after creation. This adds an edit flow from the admin panel.

## Changes in the codebase

- Edit button on the events list page that opens the event in the existing creation form
- Edit mode pre-fills all fields from the saved event, including speakers, resources, and feature toggles
- Cancel button in edit mode warns if you have unsaved changes before leaving
- Features missing from the saved event fall back to the type's default in edit mode (matches the backend's `getFeatures()` contract). Covers legacy events whose features weren't persisted by older code.
- Catalyst's timing setting is fixed at event creation. Edit mode lets the organizer toggle Catalyst on or off but hides the timing input.
- Edit mode no longer requires an end time when a start time is set. Legacy events without a saved end time can now be edited.

## Documentation and automated testing

Did you:
- [ ] document any breaking changes in your commit messages?
- [ ] document your changes as comments in the code? Use TSDoc format where appropriate.
- [ ] update the README and docs to be clear and easy to use for end users and developers?
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables?
- [ ] add a What's New entry in `content/whatsNew.ts` for new features?

## Testing this PR

- [ ] Create an event, then click Edit from the events list and verify all fields are pre-filled
- [ ] Edit an event and toggle a feature off, save, re-open edit, confirm it stays off
- [ ] Edit an event with Catalyst enabled. The Catalyst checkbox should be visible but the "Minimum Minutes Between Contributions" input should not.
- [ ] Edit an event that was saved without an end time. You should be able to advance past Step 1 and save without being blocked.
- [ ] Make a change and click Cancel. The unsaved-changes dialog should appear. "Keep editing" stays, "Discard" navigates away.
- [ ] Revert a field to its original value and click Cancel. Should navigate away with no dialog.

*Note: When you edit the event type, you should also see an info alert that says the bot name will also change.*