### PR TITLE
Fix intermittent "Channel access denied. User is not a participant" error

### DIFF
--- a/SESSION_AND_TOKEN_SYSTEM.md
+++ b/SESSION_AND_TOKEN_SYSTEM.md
@@ -1,6 +1,6 @@
 # Session & Token System — Developer Guide
 
-> **Audience:** New developers joining the Nextspace project.  
+> **Audience:** New developers joining the Nextspace project.
 > **Goal:** Give you a complete mental model of how authentication, sessions, tokens, and
 > token refresh work end-to-end — across page navigations, HTTP calls, WebSocket
 > connections, and multiple browser tabs.
@@ -84,7 +84,7 @@ The entire refresh subsystem funnels through a single class — **`TokenManager`
 | `pages/api/cookie.ts` | Next.js API route. GET = decrypt cookie and return tokens + user info + expiry timestamps. |
 | `pages/api/request.ts` | Server-side proxy: forwards requests to the backend API using cookie credentials. Adds `X-Tokens-Refreshed: true` header if it had to refresh. |
 | `pages/_app.tsx` | Calls `SessionManager.get().restoreSession()` once on app mount. |
-| `pages/login.tsx` | Calls `Api.get().SetTokens(access, refresh, accessExpires, refreshExpires)` after login. |
+| `pages/login.tsx` | Calls `Api.get().SetTokens(access, refresh, accessExpires, refreshExpires, userId)` after login. |
 
 ---
 
@@ -156,7 +156,7 @@ Called **once** by `_app.tsx` during initial render. It:
 
 1. Checks if already initialized — if so, returns immediately (prevents race on rapid navigation)
 2. Fetches `/api/cookie` to check for an existing session
-3. **If cookie exists:** calls `Api.get().SetTokens(access, refresh, accessExpires, refreshExpires)` → flows through to `TokenManager` → proactive refresh timer starts
+3. **If cookie exists:** calls `Api.get().SetTokens(access, refresh, accessExpires, refreshExpires, userId)` → flows through to `TokenManager` → proactive refresh timer starts
 4. **If no cookie** (and `skipCreation` is not true): calls `_createGuestSession()` which hits `/auth/newPseudonym` + `/auth/register`, stores tokens, creates cookie
 5. **If multiple calls arrive simultaneously:** they all await the same `initializationPromise` — no race conditions
 
@@ -197,8 +197,8 @@ type TokenSet = {
 
 | Method | Purpose |
 |---|---|
-| `setTokens(tokens, broadcast?)` | Store full token set. Triggers timer + notifies listeners + broadcasts to other tabs |
-| `setTokensFromStrings(access, refresh, accessExpires?, refreshExpires?)` | Convenience for callers that have strings. Synthesises expiry if not provided |
+| `setTokens(tokens, opts?)` | Store full token set. `opts` is `{ broadcast?: boolean; userId?: string }`. Triggers timer + notifies listeners + (by default) broadcasts to other tabs. Passing `userId` (an authoritative local write) (re)establishes the token owner |
+| `setTokensFromStrings(access, refresh, accessExpires?, refreshExpires?, userId?)` | Convenience for callers that have strings. Synthesises expiry if not provided. Forwards `userId` to set the token owner |
 | `getAccessToken()` | Returns current access token string or `""` |
 | `getTokens()` | Returns `{ access: string\|null, refresh: string\|null }` (backward-compat shape) |
 | `getFullTokens()` | Returns the full `TokenSet` including expires fields, or `null` |
@@ -224,7 +224,8 @@ type TokenSet = {
    ├─ 401 → call /api/logout, clearTokens(), return false
    ├─ other error → throw
    └─ success:
-      a. setTokens(newTokens, broadcast=true)   ← notifies listeners + other tabs
+      a. setTokens(newTokens, { broadcast: true })   ← notifies listeners + other tabs
+         (no userId passed — a refresh keeps the existing token owner)
       b. PATCH /api/session  with new tokens + expiry (retry once on failure)
       c. return true
 ```
@@ -247,6 +248,16 @@ This means if an HTTP 401 and a WebSocket connect_error both trigger `refresh()`
 
 `_lastRefreshAt` records the timestamp of the last successful refresh. If `refresh()` is called again within 10 seconds, it returns immediately without making a network call.
 
+### Token Identity Ownership
+
+`TokenManager` tracks `_ownerUserId` — the user the current tokens belong to. This prevents a tab from silently authenticating as one user while building channel names (`direct-${userId}-${agentId}`) for another, which previously caused intermittent `"User is not a participant"` errors.
+
+- **Authoritative local writes** (guest creation, login, cookie restore) call `setTokens(tokens, { userId })`. They set/replace `_ownerUserId` unconditionally.
+- **Remote adoptions** are guarded against the owner:
+  - **Cross-tab broadcast** (`_handleTabMessage`): a `TOKENS_REFRESHED` message is adopted **only** if its `userId` matches `_ownerUserId`. It is ignored when the user differs, or when this tab has no owner yet (mid-initialization). This neutralizes the race where two tabs create distinct guest sessions at the same time and broadcast each other's tokens.
+  - **Cookie sync** (`_syncFromCookie`): cookie tokens are adopted **only** if the cookie's `userId` matches `_ownerUserId`; otherwise the tab refreshes with its own refresh token instead.
+- `clearTokens()` resets `_ownerUserId` to `null`.
+
 ---
 
 ## 6. Api class (Helpers.ts) — Thin Wrapper
@@ -254,7 +265,7 @@ This means if an HTTP 401 and a WebSocket connect_error both trigger `refresh()`
 `Api` is a singleton class (`Api.get()`) that pre-dates `TokenManager`. Its token methods are now thin wrappers:
 
 ```ts
-SetTokens(access, refresh, accessExpires?, refreshExpires?)
+SetTokens(access, refresh, accessExpires?, refreshExpires?, userId?)
   → TokenManagerDefault.setTokensFromStrings(...)
 
 GetTokens()
@@ -270,7 +281,7 @@ ClearTokens()
   → TokenManagerDefault.clearTokens()
 ```
 
-**Always prefer** calling `Api.get().SetTokens(...)` (with all 4 args) or `TokenManagerDefault.setTokens(...)` directly over manipulating token state any other way.
+**Always prefer** calling `Api.get().SetTokens(...)` (with all 4 token args plus `userId` for authoritative writes) or `TokenManagerDefault.setTokens(...)` directly over manipulating token state any other way.
 
 ---
 
@@ -356,7 +367,7 @@ document.addEventListener("visibilitychange", async () => {
 })
 ```
 
-**Gap-reconnect detection:**  
+**Gap-reconnect detection:**
 If the socket was disconnected for ≥ 10 seconds before reconnecting, `lastReconnectTime` is set to `Date.now()`. Pages watch this in a `useEffect` to re-fetch message history from the REST API.
 
 ### `emitWithTokenRefresh()` (utils/tokenRefresh.ts)
@@ -398,7 +409,7 @@ When multiple tabs are open they all share the same cookie but each has its own 
 
 | Message | Sent when | Received action |
 |---|---|---|
-| `TOKENS_REFRESHED` | Any tab completes a refresh and calls `setTokens(broadcast=true)` | Other tabs call `setTokens(tokens, false)` — adopt new tokens, no echo |
+| `TOKENS_REFRESHED` | Any tab calls `setTokens` with `broadcast` enabled (refresh, and currently also identity-establishing writes). Carries the sender's `userId` | Other tabs call `setTokens(tokens, { broadcast: false })` to adopt the new tokens **only if** `message.userId` matches their own `_ownerUserId` (no echo). Mismatched/owner-less tabs ignore the message |
 | `REFRESH_STARTING` | A tab is about to call the refresh API | Other tabs log "standing by" — their proactive timer will simply not fire because by the time it does, `TOKENS_REFRESHED` will have arrived and `isAccessTokenFresh()` will return `true` |
 
 ### Multi-Tab Refresh Race Prevention
@@ -408,7 +419,7 @@ Tab A's timer fires → _doRefresh() starts:
   Step 1: GET /api/cookie → token is stale (Tab A hasn't refreshed yet)
   Step 3: broadcast REFRESH_STARTING
   Step 4: POST /auth/refresh-tokens → success
-  setTokens(newTokens, broadcast=true) → broadcasts TOKENS_REFRESHED
+  setTokens(newTokens, { broadcast: true }) → broadcasts TOKENS_REFRESHED (with owner userId)
 
 Tab B's timer fires (at nearly the same time) → _doRefresh() starts:
   Step 1: GET /api/cookie → token is FRESH (Tab A already refreshed the cookie!)
@@ -430,15 +441,16 @@ Even if Tab B's timer fires between Tab A's refresh and the `TOKENS_REFRESHED` b
 
 ### Admin login → participant page
 1. `/login` page calls the backend `/auth/login`
-2. On success: `Api.get().SetTokens(access, refresh, accessExpires, refreshExpires)` — expiry stored in `TokenManager`, proactive timer starts
+2. On success: `Api.get().SetTokens(access, refresh, accessExpires, refreshExpires, userId)` — expiry stored in `TokenManager`, token owner set to the admin `userId`, proactive timer starts
 3. `/api/session` POST — cookie updated with new tokens and expiry
 4. `SessionManager.markAuthenticated(username, userId)` — state = `"authenticated"`
 5. Navigate to `/assistant` — `SessionManager` already initialized, `TokenManager` has tokens → `useSessionJoin` uses them immediately
 
 ### Two tabs open simultaneously
 - Both tabs call `restoreSession()` → both read from `/api/cookie` → both get same tokens
-- Each tab's `TokenManager` is independent but has the same state
+- Each tab's `TokenManager` is independent but has the same state (and the same `_ownerUserId`)
 - When Tab A's proactive timer fires, Tab B gets `TOKENS_REFRESHED` broadcast and skips its own refresh
+- **No cookie yet (cold start):** if both tabs run `_createGuestSession()` at once they register *distinct* guests and broadcast each other's tokens. Each tab's owner guard rejects the other's `TOKENS_REFRESHED`, so a tab never authenticates as the other guest while building channels for its own — preventing the intermittent `"User is not a participant"` error
 
 ### Tab hidden (phone locks / browser minimized)
 - Token may expire while tab is hidden
@@ -476,7 +488,7 @@ Browser                _app.tsx              SessionManager         External API
    │                      │                       │◄─ { token, pseudonym } ─│
    │                      │                       │─ POST /auth/register ──►│
    │                      │                       │◄─ { tokens, user } ─────│
-   │                      │                       │─ Api.SetTokens() ──► TokenManager
+   │                      │                       │─ Api.SetTokens(..., userId) ──► TokenManager
    │                      │                       │─ POST /api/session ─►│  (stores with expiry,
    │                      │                       │◄─ 200 cookie set ───│   schedules timer)
    │◄── render page ──────│◄── sessionInfo ───────│
@@ -489,10 +501,10 @@ TokenManager timer fires (2 min before expiry)
   │
   ├─ GET /api/cookie → same stale token
   ├─ POST /auth/refresh-tokens → { access, refresh, expires... }
-  ├─ setTokens(newTokens, broadcast=true)
+  ├─ setTokens(newTokens, { broadcast: true })
   │    ├─ _scheduleProactiveRefresh() → new timer
   │    ├─ _notifyListeners() → useSessionJoin updates socket.auth
-  │    └─ BroadcastChannel → other tabs adopt tokens
+  │    └─ BroadcastChannel → same-user tabs adopt tokens
   └─ PATCH /api/session → cookie updated
 ```
 
@@ -508,7 +520,7 @@ Page component
   │    (dedup: WS caller may share this same promise)
   │    │─ GET /api/cookie → stale
   │    │─ POST /auth/refresh-tokens → new tokens
-  │    └─ setTokens(), PATCH /api/session
+  │    └─ setTokens(newTokens, { broadcast: true }), PATCH /api/session
   │
   │─ retry original request with new Authorization header ► Backend API
   │◄─ 200 OK ─────────────────────────────────────────────── │
@@ -520,7 +532,7 @@ Page component
 
 ### "Token refresh not working / still getting 401s"
 
-1. Check that `SetTokens` is being called with all 4 args (including `accessExpires`/`refreshExpires`). Without expiry info, the proactive timer cannot schedule correctly and `TokenManager` synthesises a 30-minute expiry instead of the real one.
+1. Check that `SetTokens` is being called with all token args (including `accessExpires`/`refreshExpires`, and `userId` for authoritative writes). Without expiry info, the proactive timer cannot schedule correctly and `TokenManager` synthesises a 30-minute expiry instead of the real one.
 2. Check the cookie: open Network tab → find `/api/cookie` request → verify `accessExpires` is present in the response JSON.
 3. Check browser console for `TokenManager: proactive refresh scheduled in Xs` — if this isn't appearing after login, expiry info is missing.
 
@@ -536,6 +548,10 @@ Page component
 - Navigation between admin and participant pages uses `router.push()` (client-side navigation) not `window.location.href = ...`
 - The cookie always has valid tokens as the source of truth — `SessionManager.restoreSession()` will reload them from the cookie on the next page
 
+### "Channel access denied / User is not a participant in direct channel"
+
+This means the tab is calling the API with an access token for one user while building the channel name `direct-${userId}-${agentId}` for a *different* user. `TokenManager` now guards against this: tokens arriving via `TOKENS_REFRESHED` broadcast or `_syncFromCookie` are only adopted if their `userId` matches `_ownerUserId`. If you see this error, check the console for `TokenManager: ignoring broadcast/cookie tokens for a different user (...)` — that means the guard fired and rejected a cross-user token. A stale build without the owner guard, or a `SetTokens` call missing its `userId`, can re-introduce the divergence.
+
 ### "Socket disconnects when token refreshes"
 
 This is by design — `socket.auth` is updated with the new token but `connect()` is only called if the socket is **disconnected**. If the socket is connected, it will use the new token on the next reconnection. The socket itself doesn't need to be reconnected just because the token changed.
@@ -550,7 +566,9 @@ Check that the backend's clock and the client's clock are roughly in sync. `REFR
 |---|---|
 | `TokenManager: proactive refresh scheduled in Xs` | Expiry correctly parsed, timer set |
 | `TokenManager: tokens already refreshed (cookie sync)` | Multi-tab safety worked; skipped network call |
-| `TokenManager: received refreshed tokens from another tab` | BroadcastChannel delivered tokens |
+| `TokenManager: received refreshed tokens from another tab` | BroadcastChannel delivered tokens for the same user (adopted) |
+| `TokenManager: ignoring broadcast tokens for a different user (...)` | Owner guard rejected a cross-user `TOKENS_REFRESHED` (expected when distinct guests are open in multiple tabs) |
+| `TokenManager: ignoring cookie tokens for a different user (...)` | Owner guard rejected cookie tokens during `_syncFromCookie`; the tab refreshes its own session instead |
 | `TokenManager: another tab is refreshing — standing by` | Received REFRESH_STARTING |
 | `TokenManager: token refresh successful` | Full refresh cycle completed |
 | `TokenManager: refresh token expired, logging out` | Both tokens expired; user will be redirected |
@@ -566,7 +584,7 @@ All tests live in `__tests__/utils/` and `__tests__/integration/`.
 
 | Test File | What It Covers |
 |---|---|
-| `TokenManager.test.ts` | Token storage/retrieval, `isAccessTokenFresh`, `getValidToken`, refresh deduplication, rate-limiting, cookie sync (multi-tab), cookie PATCH + retry, proactive scheduling, `onTokensChanged` (single + multiple listeners), BroadcastChannel (broadcast, receive, timer reschedule, REFRESH_STARTING), edge cases (no tokens, empty response, 401→logout) |
+| `TokenManager.test.ts` | Token storage/retrieval, `isAccessTokenFresh`, `getValidToken`, refresh deduplication, rate-limiting, cookie sync (multi-tab), cookie PATCH + retry, proactive scheduling, `onTokensChanged` (single + multiple listeners), BroadcastChannel (broadcast, receive, timer reschedule, REFRESH_STARTING), token identity ownership (reject cross-user broadcast, ignore broadcast with no owner, `_syncFromCookie` cross-user rejection, authoritative owner update guest→admin), edge cases (no tokens, empty response, 401→logout) |
 | `tokenRefresh.test.ts` | `ensureFreshToken` delegate, `refreshAccessToken` delegate, `emitWithTokenRefresh` (no token, emit, retry on 401, retry fail, non-auth error) |
 | `useSessionJoin.test.ts` | Init, session info, socket creation, connect/disconnect state, connect_error (auth + non-auth), visibility change (disconnected → reconnect, connected → no reconnect), onTokensChanged (subscribe, update auth, connected → no connect(), unsubscribe), gap-reconnect detection |
 | `SessionManager.test.ts` | Singleton, session restore from cookie, guest detection, new guest creation, dedup on concurrent calls, auth/guest state transitions, `skipCreation` option, error handling |

--- a/__tests__/pages/assistant.test.tsx
+++ b/__tests__/pages/assistant.test.tsx
@@ -1442,28 +1442,34 @@ describe('EventAssistantRoom', () => {
 
       await waitFor(() => expect(mockSocket.on).toHaveBeenCalledWith('message:new', expect.any(Function)));
 
-      const messageHandler: Function = mockSocket.on.mock.calls
-        .filter(([event]: [string]) => event === 'message:new')
-        .map(([, handler]: [string, Function]) => handler)
-        .at(-1)!;
-
       const user = userEvent.setup();
       await waitFor(() => expect(screen.getAllByLabelText('Berkie').length).toBeGreaterThan(0));
       await user.click(screen.getAllByLabelText('Berkie')[0]);
 
+      // A real socket broadcasts 'message:new' to every registered listener. The
+      // assistant page AND the Transcript sidebar (mounted because the route has
+      // a transcript passcode) each register one, so we must invoke all of them
+      // rather than guessing which registration is the assistant page's. Capture
+      // after the click so any re-registrations have settled.
+      const messageHandlers: Function[] = mockSocket.on.mock.calls
+        .filter(([event]: [string]) => event === 'message:new')
+        .map(([, handler]: [string, Function]) => handler);
+
       act(() => {
-        messageHandler({
-          id: 'msg-jargon-1',
-          body: { type: 'jargon_clarification', text: 'An SLO is a reliability target.', sourceText: 'Our SLOs...' },
-          bodyType: 'json',
-          fromAgent: true,
-          channels: ['direct-user-123-jargon-agent-456'],
-          pseudonym: 'Jargon Filter Agent',
-          pause: false,
-          visible: true,
-          upVotes: [],
-          downVotes: [],
-        });
+        messageHandlers.forEach((handler) =>
+          handler({
+            id: 'msg-jargon-1',
+            body: { type: 'jargon_clarification', text: 'An SLO is a reliability target.', sourceText: 'Our SLOs...' },
+            bodyType: 'json',
+            fromAgent: true,
+            channels: ['direct-user-123-jargon-agent-456'],
+            pseudonym: 'Jargon Filter Agent',
+            pause: false,
+            visible: true,
+            upVotes: [],
+            downVotes: [],
+          }),
+        );
       });
 
       await waitFor(() => {

--- a/__tests__/utils/SessionManager.test.ts
+++ b/__tests__/utils/SessionManager.test.ts
@@ -80,13 +80,15 @@ describe('SessionManager', () => {
 
       expect(result).toEqual({ userId: 'user-123', username: 'testuser' });
       expect(global.fetch).toHaveBeenCalledWith('/api/cookie');
-      // SetTokens is now called with 4 params; last two may be undefined when
-      // the cookie doesn't include accessExpires / refreshExpires.
+      // SetTokens is now called with 5 params; expires are undefined when the
+      // cookie doesn't include them, and the userId is passed so TokenManager
+      // can reject cross-user tokens arriving via broadcast / cookie sync.
       expect(mockApiInstance.SetTokens).toHaveBeenCalledWith(
         'mock-access-token',
         'mock-refresh-token',
         undefined,
         undefined,
+        'user-123',
       );
       expect(sessionManager.getState()).toBe('authenticated');
     });

--- a/__tests__/utils/TokenManager.test.ts
+++ b/__tests__/utils/TokenManager.test.ts
@@ -678,11 +678,12 @@ describe('TokenManager', () => {
         access: { token: 'acc', expires: FUTURE_ACCESS_EXPIRES },
         refresh: { token: 'ref', expires: FUTURE_REFRESH_EXPIRES },
       };
-      tokenManager.setTokens(tokens, true);
+      tokenManager.setTokens(tokens, { broadcast: true });
 
       expect(mockBroadcastPostMessage).toHaveBeenCalledWith({
         type: 'TOKENS_REFRESHED',
         tokens,
+        userId: null,
       });
     });
 
@@ -692,13 +693,22 @@ describe('TokenManager', () => {
           access: { token: 'acc', expires: FUTURE_ACCESS_EXPIRES },
           refresh: { token: 'ref', expires: FUTURE_REFRESH_EXPIRES },
         },
-        false,
+        { broadcast: false },
       );
 
       expect(mockBroadcastPostMessage).not.toHaveBeenCalled();
     });
 
     it('reschedules the proactive refresh timer when adopting tokens from another tab', () => {
+      // Establish this tab's token owner so a same-user broadcast is accepted.
+      tokenManager.setTokens(
+        {
+          access: { token: 'acc', expires: FUTURE_ACCESS_EXPIRES },
+          refresh: { token: 'ref', expires: FUTURE_REFRESH_EXPIRES },
+        },
+        { userId: 'user-1' },
+      );
+
       const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
       setTimeoutSpy.mockClear();
 
@@ -707,9 +717,9 @@ describe('TokenManager', () => {
         refresh: { token: 'tab2-ref', expires: FUTURE_REFRESH_EXPIRES },
       };
 
-      // Simulate another tab broadcasting refreshed tokens
+      // Simulate another tab (same user) broadcasting refreshed tokens
       broadcastMessageHandler?.({
-        data: { type: 'TOKENS_REFRESHED', tokens: newTokens },
+        data: { type: 'TOKENS_REFRESHED', tokens: newTokens, userId: 'user-1' },
       } as MessageEvent);
 
       // setTokens(broadcast=false) is called internally, which triggers
@@ -738,17 +748,71 @@ describe('TokenManager', () => {
     });
 
     it('receives TOKENS_REFRESHED from another tab and updates tokens without re-broadcasting', () => {
+      // Establish this tab's token owner so a same-user broadcast is accepted.
+      tokenManager.setTokens(
+        {
+          access: { token: 'acc', expires: FUTURE_ACCESS_EXPIRES },
+          refresh: { token: 'ref', expires: FUTURE_REFRESH_EXPIRES },
+        },
+        { userId: 'user-1' },
+      );
+      mockBroadcastPostMessage.mockClear();
+
       const newTokens = {
         access: { token: 'cross-tab-acc', expires: FUTURE_ACCESS_EXPIRES },
         refresh: { token: 'cross-tab-ref', expires: FUTURE_REFRESH_EXPIRES },
       };
 
       broadcastMessageHandler?.({
-        data: { type: 'TOKENS_REFRESHED', tokens: newTokens },
+        data: { type: 'TOKENS_REFRESHED', tokens: newTokens, userId: 'user-1' },
       } as MessageEvent);
 
       expect(tokenManager.getAccessToken()).toBe('cross-tab-acc');
       expect(mockBroadcastPostMessage).not.toHaveBeenCalled();
+    });
+
+    it('IGNORES TOKENS_REFRESHED from another tab when the userId differs from ours', () => {
+      // This tab belongs to user-1.
+      tokenManager.setTokens(
+        {
+          access: { token: 'user1-acc', expires: FUTURE_ACCESS_EXPIRES },
+          refresh: { token: 'user1-ref', expires: FUTURE_REFRESH_EXPIRES },
+        },
+        { userId: 'user-1' },
+      );
+
+      // Another tab (user-2) broadcasts ITS tokens. Adopting them would make us
+      // authenticate as user-2 while building channels for user-1.
+      broadcastMessageHandler?.({
+        data: {
+          type: 'TOKENS_REFRESHED',
+          tokens: {
+            access: { token: 'user2-acc', expires: FUTURE_ACCESS_EXPIRES },
+            refresh: { token: 'user2-ref', expires: FUTURE_REFRESH_EXPIRES },
+          },
+          userId: 'user-2',
+        },
+      } as MessageEvent);
+
+      // Our tokens are unchanged — the foreign tokens were rejected.
+      expect(tokenManager.getAccessToken()).toBe('user1-acc');
+    });
+
+    it('IGNORES TOKENS_REFRESHED when we have no owner yet (tab mid-initialization)', () => {
+      // No setTokens call yet → no owner. A broadcast arriving now (e.g. another
+      // tab creating a distinct guest session) must not establish our identity.
+      broadcastMessageHandler?.({
+        data: {
+          type: 'TOKENS_REFRESHED',
+          tokens: {
+            access: { token: 'other-acc', expires: FUTURE_ACCESS_EXPIRES },
+            refresh: { token: 'other-ref', expires: FUTURE_REFRESH_EXPIRES },
+          },
+          userId: 'user-2',
+        },
+      } as MessageEvent);
+
+      expect(tokenManager.getAccessToken()).toBe('');
     });
 
     it('broadcasts REFRESH_STARTING when a refresh begins', async () => {
@@ -785,6 +849,100 @@ describe('TokenManager', () => {
 
       const startMsg = mockBroadcastPostMessage.mock.calls.find((call: any[]) => call[0]?.type === 'REFRESH_STARTING');
       expect(startMsg).toBeDefined();
+    });
+  });
+
+  // ─── Identity ownership guard ─────────────────────────────────────────────
+
+  describe('token identity ownership', () => {
+    it('_syncFromCookie ignores cookie tokens that belong to a different user', async () => {
+      (global.fetch as jest.Mock)
+        // /api/cookie — another tab/login overwrote the shared cookie with user-2
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            tokens: {
+              access: 'user2-acc',
+              refresh: 'user2-ref',
+              accessExpires: FUTURE_ACCESS_EXPIRES,
+            },
+            userId: 'user-2',
+          }),
+        })
+        // refresh API — called because the cookie was rejected; returns fresh user-1 tokens
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access: { token: 'user1-new-acc', expires: FUTURE_ACCESS_EXPIRES },
+            refresh: { token: 'user1-new-ref', expires: FUTURE_REFRESH_EXPIRES },
+          }),
+        })
+        // PATCH /api/session
+        .mockResolvedValueOnce({ ok: true });
+
+      // This tab belongs to user-1 with a near-expiry token to trigger refresh.
+      tokenManager.setTokens(
+        {
+          access: { token: 'user1-acc', expires: NEAR_EXPIRY_ACCESS },
+          refresh: { token: 'user1-ref', expires: FUTURE_REFRESH_EXPIRES },
+        },
+        { userId: 'user-1' },
+      );
+
+      await flush();
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+
+      // The cookie's user-2 token was never adopted; we refreshed our own session.
+      expect(tokenManager.getAccessToken()).not.toBe('user2-acc');
+      expect(tokenManager.getAccessToken()).toBe('user1-new-acc');
+    });
+
+    it('authoritative local setTokens updates the owner (guest → admin via login)', () => {
+      // Guest session establishes owner = guest-1.
+      tokenManager.setTokens(
+        {
+          access: { token: 'guest-acc', expires: FUTURE_ACCESS_EXPIRES },
+          refresh: { token: 'guest-ref', expires: FUTURE_REFRESH_EXPIRES },
+        },
+        { userId: 'guest-1' },
+      );
+      mockBroadcastPostMessage.mockClear();
+
+      // Login as admin in the same tab — an authoritative local write updates owner.
+      tokenManager.setTokensFromStrings(
+        'admin-acc',
+        'admin-ref',
+        FUTURE_ACCESS_EXPIRES,
+        FUTURE_REFRESH_EXPIRES,
+        'admin-1',
+      );
+
+      expect(tokenManager.getAccessToken()).toBe('admin-acc');
+
+      // The broadcast carries the NEW owner so other tabs validate against admin-1.
+      expect(mockBroadcastPostMessage).toHaveBeenCalledWith({
+        type: 'TOKENS_REFRESHED',
+        tokens: {
+          access: { token: 'admin-acc', expires: FUTURE_ACCESS_EXPIRES },
+          refresh: { token: 'admin-ref', expires: FUTURE_REFRESH_EXPIRES },
+        },
+        userId: 'admin-1',
+      });
+
+      // A late broadcast for the OLD guest user is now rejected.
+      broadcastMessageHandler?.({
+        data: {
+          type: 'TOKENS_REFRESHED',
+          tokens: {
+            access: { token: 'guest-acc-2', expires: FUTURE_ACCESS_EXPIRES },
+            refresh: { token: 'guest-ref-2', expires: FUTURE_REFRESH_EXPIRES },
+          },
+          userId: 'guest-1',
+        },
+      } as MessageEvent);
+
+      expect(tokenManager.getAccessToken()).toBe('admin-acc');
     });
   });
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -58,16 +58,18 @@ export default function LoginPage() {
         return;
       }
 
+      const userId = response.user?.id || response.userId;
+
       // Store tokens with expiry info so TokenManager can schedule
-      // proactive refresh correctly.
+      // proactive refresh correctly.  Pass the userId so TokenManager knows
+      // which user these tokens belong to.
       Api.get().SetTokens(
         response.tokens.access.token,
         response.tokens.refresh.token,
         response.tokens.access.expires,
         response.tokens.refresh.expires,
+        userId,
       );
-
-      const userId = response.user?.id || response.userId;
 
       // Get the active pseudonym for the user
       const activePseudonym = response.user?.pseudonyms?.find((p: any) => p.active)?.pseudonym;

--- a/utils/Helpers.ts
+++ b/utils/Helpers.ts
@@ -85,9 +85,13 @@ export class Api {
    * @param refresh       Raw refresh token string.
    * @param accessExpires Optional ISO-8601 expiry for the access token.
    * @param refreshExpires Optional ISO-8601 expiry for the refresh token.
+   * @param userId        Optional id of the user the tokens belong to.  Pass it
+   *                      from authoritative writes (guest creation, login,
+   *                      cookie restore) so TokenManager can reject tokens that
+   *                      arrive cross-tab / via cookie for a different user.
    */
-  SetTokens(access: string, refresh: string, accessExpires?: string, refreshExpires?: string) {
-    TokenManagerDefault.setTokensFromStrings(access, refresh, accessExpires, refreshExpires);
+  SetTokens(access: string, refresh: string, accessExpires?: string, refreshExpires?: string, userId?: string) {
+    TokenManagerDefault.setTokensFromStrings(access, refresh, accessExpires, refreshExpires, userId);
   }
 
   /**

--- a/utils/SessionManager.ts
+++ b/utils/SessionManager.ts
@@ -61,8 +61,15 @@ class SessionManager {
 
       if (response.status === 200 && data.tokens) {
         // Valid session cookie exists — restore tokens with expiry info so
-        // TokenManager can schedule the proactive refresh correctly.
-        Api.get().SetTokens(data.tokens.access, data.tokens.refresh, data.tokens.accessExpires, data.tokens.refreshExpires);
+        // TokenManager can schedule the proactive refresh correctly.  Pass the
+        // userId so TokenManager knows which user these tokens belong to.
+        Api.get().SetTokens(
+          data.tokens.access,
+          data.tokens.refresh,
+          data.tokens.accessExpires,
+          data.tokens.refreshExpires,
+          data.userId,
+        );
 
         // Determine if this is a guest or authenticated user using the
         // authType field stored in the cookie (set when the session was created).
@@ -116,12 +123,15 @@ class SessionManager {
         }),
       }).then((res) => res.json());
 
-      // Set tokens in memory (with expiry so TokenManager can schedule refresh)
+      // Set tokens in memory (with expiry so TokenManager can schedule refresh).
+      // Pass the userId so TokenManager refuses tokens broadcast from a sibling
+      // tab that created its own distinct guest session at the same time.
       Api.get().SetTokens(
         registerResponse.tokens.access.token,
         registerResponse.tokens.refresh.token,
         registerResponse.tokens.access.expires,
         registerResponse.tokens.refresh.expires,
+        registerResponse.user.id,
       );
 
       // Set encrypted cookie via API route, including expiry timestamps so

--- a/utils/TokenManager.ts
+++ b/utils/TokenManager.ts
@@ -40,13 +40,23 @@ type TokenChangeListener = (tokens: TokenSet) => void;
 
 /**
  * BroadcastChannel message types for cross-tab coordination.
+ *
+ * TOKENS_REFRESHED carries the `userId` the tokens belong to so receiving tabs
+ * can refuse to adopt tokens for a different user (which would cause the tab to
+ * authenticate as one user while building channel names for another).
  */
-type TabMessage = { type: 'TOKENS_REFRESHED'; tokens: TokenSet } | { type: 'REFRESH_STARTING' };
+type TabMessage =
+  | { type: 'TOKENS_REFRESHED'; tokens: TokenSet; userId: string | null }
+  | { type: 'REFRESH_STARTING' };
 
 class TokenManagerClass {
   private static _instance: TokenManagerClass;
 
   private _tokens: TokenSet | null = null;
+  // The user the current tokens belong to.  Set by authoritative local writes
+  // (guest creation, login, cookie restore, in-tab refresh).  Used to reject
+  // tokens from other users arriving via BroadcastChannel or cookie sync.
+  private _ownerUserId: string | null = null;
   private _inflightRefresh: Promise<boolean> | null = null;
   private _proactiveTimer: ReturnType<typeof setTimeout> | null = null;
   private _lastRefreshAt: number = 0;
@@ -73,15 +83,25 @@ class TokenManagerClass {
    * refresh and notifies subscribers + other tabs.
    *
    * @param tokens  Full token set including expires timestamps.
-   * @param broadcast  Set false when the tokens came from a broadcast (to
-   *                   avoid an infinite loop). Defaults to true.
+   * @param opts.broadcast  Set false when the tokens came from a broadcast or
+   *                        cookie sync (to avoid an infinite loop). Defaults to true.
+   * @param opts.userId  The user the tokens belong to.  Provided by authoritative
+   *                     local writes (guest creation, login, cookie restore) to
+   *                     (re)establish the token owner.  When omitted the existing
+   *                     owner is preserved (e.g. an in-tab refresh keeps the same
+   *                     user).  The owner is broadcast so other tabs can reject
+   *                     tokens that belong to a different user.
    */
-  setTokens(tokens: TokenSet, broadcast = true): void {
+  setTokens(tokens: TokenSet, opts: { broadcast?: boolean; userId?: string | null } = {}): void {
+    const { broadcast = true, userId } = opts;
     this._tokens = tokens;
+    if (userId !== undefined) {
+      this._ownerUserId = userId;
+    }
     this._scheduleProactiveRefresh();
     this._notifyListeners(tokens);
     if (broadcast) {
-      this._broadcast({ type: 'TOKENS_REFRESHED', tokens });
+      this._broadcast({ type: 'TOKENS_REFRESHED', tokens, userId: this._ownerUserId });
     }
   }
 
@@ -89,17 +109,26 @@ class TokenManagerClass {
    * Convenience overload for callers that only have token strings and expiry
    * info available at the same time.
    */
-  setTokensFromStrings(accessToken: string, refreshToken: string, accessExpires?: string, refreshExpires?: string): void {
+  setTokensFromStrings(
+    accessToken: string,
+    refreshToken: string,
+    accessExpires?: string,
+    refreshExpires?: string,
+    userId?: string,
+  ): void {
     // When expires info is unavailable (legacy callers) synthesise a plausible
     // expiry so scheduling still works — 30 min for access, 30 days for refresh.
     const now = Date.now();
     const safeAccessExpires = accessExpires ?? new Date(now + 30 * 60 * 1000).toISOString();
     const safeRefreshExpires = refreshExpires ?? new Date(now + 30 * 24 * 60 * 60 * 1000).toISOString();
 
-    this.setTokens({
-      access: { token: accessToken, expires: safeAccessExpires },
-      refresh: { token: refreshToken, expires: safeRefreshExpires },
-    });
+    this.setTokens(
+      {
+        access: { token: accessToken, expires: safeAccessExpires },
+        refresh: { token: refreshToken, expires: safeRefreshExpires },
+      },
+      { userId },
+    );
   }
 
   /**
@@ -181,6 +210,7 @@ class TokenManagerClass {
    */
   clearTokens(): void {
     this._tokens = null;
+    this._ownerUserId = null;
     this._cancelProactiveRefresh();
   }
 
@@ -240,8 +270,10 @@ class TokenManagerClass {
           },
         };
 
-        // Update in-memory store and schedule next refresh.
-        this.setTokens(newTokens, true); // broadcasts to other tabs
+        // Update in-memory store and schedule next refresh.  An in-tab refresh
+        // keeps the same user, so we don't pass userId — the existing owner is
+        // preserved and broadcast to other tabs.
+        this.setTokens(newTokens, { broadcast: true }); // broadcasts to other tabs
         this._lastRefreshAt = Date.now();
 
         // Persist to the cookie so server-side routes and other tabs can read.
@@ -273,6 +305,19 @@ class TokenManagerClass {
 
       const cookieAccess = data.tokens.access as string;
       const cookieRefresh = data.tokens.refresh as string;
+      const cookieUserId = (data.userId ?? null) as string | null;
+
+      // Refuse to adopt tokens belonging to a different user.  The cookie is
+      // shared across tabs, so another tab (or a login) may have overwritten it
+      // with a different user's session.  Adopting it here would make this tab
+      // authenticate as that user while still building channel names for our own
+      // user.  Let the caller fall back to refreshing with our own refresh token.
+      if (this._ownerUserId !== null && cookieUserId !== null && cookieUserId !== this._ownerUserId) {
+        console.warn(
+          `TokenManager: ignoring cookie tokens for a different user (cookie=${cookieUserId}, owner=${this._ownerUserId})`,
+        );
+        return false;
+      }
 
       // Only update if the cookie has a different (presumably newer) token.
       if (cookieAccess !== this._tokens?.access.token) {
@@ -287,7 +332,7 @@ class TokenManagerClass {
               expires: data.tokens.refreshExpires ?? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
             },
           },
-          false, // don't re-broadcast — this came from the cookie
+          { broadcast: false }, // don't re-broadcast — this came from the cookie
         );
         return true;
       }
@@ -449,10 +494,19 @@ class TokenManagerClass {
   private _handleTabMessage(message: TabMessage): void {
     switch (message.type) {
       case 'TOKENS_REFRESHED': {
-        // Another tab completed a refresh — adopt its tokens without triggering
-        // our own refresh.  The `broadcast=false` flag prevents an echo loop.
+        // Another tab completed a refresh.  Only adopt its tokens if they belong
+        // to the same user as ours — otherwise we'd authenticate as that user
+        // while building channel names for our own user.  Ignore when we have no
+        // owner yet (a tab mid-initialization must not adopt another tab's
+        // identity, e.g. two tabs creating distinct guest sessions at once).
+        if (this._ownerUserId === null || message.userId !== this._ownerUserId) {
+          console.warn(
+            `TokenManager: ignoring broadcast tokens for a different user (message=${message.userId}, owner=${this._ownerUserId})`,
+          );
+          break;
+        }
         console.log('TokenManager: received refreshed tokens from another tab');
-        this.setTokens(message.tokens, false);
+        this.setTokens(message.tokens, { broadcast: false });
         break;
       }
 


### PR DESCRIPTION
## What is in this PR?

Fixes an intermittent **"Channel access denied. User is not a participant"** error caused by `TokenManager` adopting tokens that belong to a *different* user. During cold-start races (e.g. two tabs creating guest sessions simultaneously, or a cookie sync overwriting freshly-issued tokens), `SessionManager.userId` could diverge from the user the tokens were actually minted for, so channel names like `direct-${userId}-${agentId}` were built for a user the socket token didn't authorize.

The fix makes `TokenManager` **identity-aware**: it tracks the user that owns the current tokens and rejects cross-tab broadcasts and cookie-sync tokens that belong to a different user.

## Changes in the codebase

- **`utils/TokenManager.ts`**: Added `_ownerUserId` to track the user owning the current tokens. `setTokens(tokens, { broadcast?, userId? })` now records the owner on authoritative writes and includes `userId` in `TOKENS_REFRESHED` broadcasts. Added guards in `_handleTabMessage` (adopt a broadcast only when `message.userId === _ownerUserId`) and `_syncFromCookie` (ignore cookie tokens whose `userId` differs from the current owner, triggering a refresh instead). `clearTokens()` resets the owner.
- **`utils/Helpers.ts`**: `Api.SetTokens(...)` takes an optional `userId` and forwards it through `setTokensFromStrings`.
- **`utils/SessionManager.ts` / `pages/login.tsx`**: Thread `userId` through the three authoritative token-write call sites (cookie restore, guest create, login).
- **`__tests__/utils/TokenManager.test.ts` / `SessionManager.test.ts`**: Updated for the new `setTokens` signature; added coverage for cross-user broadcast/cookie rejection and authoritative owner updates.
- **`__tests__/pages/assistant.test.tsx`**: Fixed a pre-existing failing test (`displays real-time messages from any agent direct channel`). It grabbed `.at(-1)` of the `message:new` listeners, which collided with the `Transcript` sidebar's own listener; now it dispatches `message:new` to *all* registered handlers, faithfully simulating a socket broadcast.
- **`SESSION_AND_TOKEN_SYSTEM.md`**: Documented token identity ownership, updated the refresh-flow diagrams/pseudocode, the two-tab race scenario, console-log reference, and added a "Channel access denied" pitfall entry.

## Documentation and automated testing

Did you:
- [x] document any breaking changes in your commit messages? (none — `setTokens`/`SetTokens` changes are backward compatible via optional params)
- [x] document your changes as comments in the code? Use TSDoc format where appropriate.
- [x] update the README and docs to be clear and easy to use for end users and developers? (updated `SESSION_AND_TOKEN_SYSTEM.md`)
- [x] add and/or update automated tests?
- [ ] update team documentation of any new or changed environment variables? (n/a)
- [ ] add a What's New entry in `content/whatsNew.ts` for new features? (n/a — internal bug fix)

## Testing this PR

- [ ] Open the app in two tabs simultaneously from a cold start (no existing session) and confirm neither tab hits "Channel access denied / User is not a participant".
- [ ] Log in as a user in one tab while another tab holds a guest session; confirm the guest tab does not adopt the logged-in user's tokens (watch console for the identity-guard warnings).
- [ ] Confirm normal token refresh still propagates across tabs for the *same* user.
- [ ] All tests should app

## Additional information

Known follow-up (out of scope): the gap-reconnect re-fetch in `pages/assistant.tsx` (~line 611) does a full `setAssistantMessages` replace and could drop a real-time message that arrives mid-fetch — worth hardening to a merge later.
